### PR TITLE
fix: Replace audio libraries with full pipewire

### DIFF
--- a/ubuntu-intune/build_files/build
+++ b/ubuntu-intune/build_files/build
@@ -31,7 +31,7 @@ apt install -y \
   unattended-upgrades \
   microsoft-identity-broker \
   microsoft-edge-stable \
-  pipewire-audio-client-libraries \
+  pipewire \
   xdg-desktop-portal-gtk \
   pcscd \
   yubikey-manager \


### PR DESCRIPTION
Potential fix for screen sharing not working under edge