### PR TITLE
fix: Unset DISPLAY when Wayland is in use for Edge

### DIFF
--- a/ubuntu-intune/system_files/usr/local/bin/microsoft-edge
+++ b/ubuntu-intune/system_files/usr/local/bin/microsoft-edge
@@ -2,6 +2,7 @@
 
 if [ -n "$WAYLAND_DISPLAY" ]
 then
+    unset -v DISPLAY
     set -- \
         '--enable-features=UseOzonePlatform' \
         '--enable-features=WebRTCPipeWireCapturer' \


### PR DESCRIPTION
Fixes an issue where Edge instantly crashes when trying to share the screen from inside the container