### PR TITLE
fix: Don't apply the latest tag when building on a schedule

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -72,8 +72,8 @@ jobs:
         id: metadata
         with:
           tags: |
-            type=raw,value=${{ env.DEFAULT_TAG }}
-            type=raw,value=${{ env.DEFAULT_TAG }}.{{date 'YYYYMMDD'}}
+            type=raw,value=${{ env.DEFAULT_TAG }},enable=${{ github.event_name != 'schedule' }}
+            type=raw,value=${{ env.DEFAULT_TAG }}.{{date 'YYYYMMDD'}},enable=${{ github.event_name != 'schedule' }}
             type=raw,value=${{ env.CHECKED_OUT_TAG }},enable=${{ github.event_name == 'schedule' }}
             type=raw,value=${{ env.CHECKED_OUT_TAG }}-{{date 'YYYYMMDD'}},enable=${{ github.event_name == 'schedule' }}
             type=raw,value={{date 'YYYYMMDD'}}


### PR DESCRIPTION
Scheduled builds will only update the newest tag, IE v0.5.0

`:latest` is reserved for the last build, which allows us to use it for testing purposes.