### PR TITLE
fix: support GNOME Shell 49 in extension

### DIFF
--- a/cmd/extension/metadata.json
+++ b/cmd/extension/metadata.json
@@ -2,7 +2,7 @@
     "uuid": "intuneme@frostyard.org",
     "name": "Intuneme",
     "description": "Manage the Intune container from Quick Settings",
-    "shell-version": ["47", "48"],
+    "shell-version": ["47", "48", "49"],
     "version": 1,
     "url": "https://github.com/frostyard/intuneme"
 }


### PR DESCRIPTION
## Problem

`intuneme extension install` copies the extension files successfully but then fails with:

```
Extension "intuneme@frostyard.org" does not exist
warning: could not enable extension: exit status 2
```

## Root cause

`metadata.json` declared `shell-version: ["47", "48"]`. GNOME Shell silently rejects extensions whose `shell-version` doesn't include the running shell version — causing `gnome-extensions enable` to report "does not exist" even though the files are present on disk.

Bluefin (and other distros on the GNOME 49 release) ship GNOME Shell 49.x.

## Fix

Add `"49"` to the `shell-version` array.

## Tested on

Bluefin (GNOME Shell 49.4) — extension loads and activates correctly after re-login.