### PR TITLE
feat: add intuneme open edge/portal commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,23 @@ A Quick Settings toggle lets you start/stop the container and open a shell witho
 intuneme extension install
 ```
 
-Log out and back in to activate. The toggle appears in Quick Settings with the container's current state. Clicking it starts or stops the container, and the popup menu shows status details and an "Open Shell" shortcut.
+Log out and back in to activate. The toggle appears in Quick Settings with the container's current state. Clicking it starts or stops the container, and the popup menu shows status details and shortcuts to open a shell, launch Edge, or launch Intune Portal.
 
 The extension monitors container state via D-Bus signals from `systemd-machined` for instant updates, with periodic polling as a fallback. Requires GNOME Shell 47+.
+
+## Desktop shortcuts
+
+Install `.desktop` entries for Edge and Intune Portal so they appear in the GNOME application grid:
+
+```bash
+bash scripts/install-desktop-items.sh
+```
+
+Clicking either entry runs `intuneme open edge` or `intuneme open portal` — the container must already be running. To remove the entries:
+
+```bash
+bash scripts/install-desktop-items.sh --uninstall
+```
 
 ## Commands
 
@@ -117,6 +131,8 @@ The extension monitors container state via D-Bus signals from `systemd-machined`
 | `intuneme init` | Pull the OCI image, extract rootfs, install Edge, configure user/PAM/services |
 | `intuneme start` | Boot the container |
 | `intuneme shell` | Open an interactive shell (real logind session with D-Bus and keyring) |
+| `intuneme open edge` | Launch Microsoft Edge inside the container |
+| `intuneme open portal` | Launch Intune Portal inside the container |
 | `intuneme stop` | Shut down the container |
 | `intuneme status` | Show whether the container is initialized and running |
 | `intuneme recreate` | Upgrade the container image, preserving enrollment state |

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/frostyard/intuneme/internal/config"
+	"github.com/frostyard/intuneme/internal/nspawn"
+	"github.com/frostyard/intuneme/internal/runner"
+	"github.com/spf13/cobra"
+)
+
+var openCmd = &cobra.Command{
+	Use:   "open",
+	Short: "Launch an application inside the running container",
+}
+
+func makeOpenAppCmd(use, short, command string) *cobra.Command {
+	return &cobra.Command{
+		Use:   use,
+		Short: short,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			r := &runner.SystemRunner{}
+			root := rootDir
+			if root == "" {
+				root = config.DefaultRoot()
+			}
+
+			cfg, err := config.Load(root)
+			if err != nil {
+				return err
+			}
+
+			if _, err := os.Stat(cfg.RootfsPath); err != nil {
+				return fmt.Errorf("not initialized — run 'intuneme init' first")
+			}
+
+			if !nspawn.IsRunning(r, cfg.MachineName) {
+				return fmt.Errorf("container is not running — run 'intuneme start' first")
+			}
+
+			return nspawn.Exec(r, cfg.MachineName, cfg.HostUser, cfg.HostUID, command)
+		},
+	}
+}
+
+func init() {
+	openCmd.AddCommand(makeOpenAppCmd(
+		"edge",
+		"Launch Microsoft Edge inside the container",
+		"microsoft-edge",
+	))
+	openCmd.AddCommand(makeOpenAppCmd(
+		"portal",
+		"Launch Intune Portal inside the container",
+		"intune-portal",
+	))
+	rootCmd.AddCommand(openCmd)
+}

--- a/internal/nspawn/nspawn.go
+++ b/internal/nspawn/nspawn.go
@@ -141,6 +141,48 @@ func BuildShellArgs(machine, user string) []string {
 	return []string{"shell", fmt.Sprintf("%s@%s", user, machine), "/bin/bash", "--login"}
 }
 
+// LeaderPID returns the PID of the container's init process (Leader) as reported
+// by machinectl, which is used to enter the container's namespaces via nsenter.
+func LeaderPID(r runner.Runner, machine string) (string, error) {
+	out, err := r.Run("machinectl", "show", machine, "-p", "Leader", "--value")
+	if err != nil {
+		return "", fmt.Errorf("machinectl show failed: %w", err)
+	}
+	pid := strings.TrimSpace(string(out))
+	if pid == "" {
+		return "", fmt.Errorf("could not determine container leader PID")
+	}
+	return pid, nil
+}
+
+// Exec runs a command non-interactively inside the container as the given user
+// and returns immediately. Uses nsenter to avoid requiring a PTY.
+func Exec(r runner.Runner, machine, user string, uid int, command string) error {
+	leaderPID, err := LeaderPID(r, machine)
+	if err != nil {
+		return err
+	}
+	uidStr := fmt.Sprintf("%d", uid)
+	script := fmt.Sprintf(
+		`export DISPLAY=:0
+export XAUTHORITY=/run/host-xauthority
+export WAYLAND_DISPLAY=/run/host-wayland
+export PIPEWIRE_REMOTE=/run/host-pipewire
+export PULSE_SERVER=unix:/run/host-pulse
+export XDG_RUNTIME_DIR=/run/user/%s
+export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/%s/bus
+nohup %s >/dev/null 2>&1 &`,
+		uidStr, uidStr, command,
+	)
+	nsenterArgs := []string{
+		"nsenter",
+		"-t", leaderPID,
+		"-m", "-u", "-i", "-n", "-p",
+		"--", "/bin/su", "-s", "/bin/bash", user, "-c", script,
+	}
+	return r.RunBackground("sudo", nsenterArgs...)
+}
+
 // Boot starts the nspawn container in the background using sudo.
 func Boot(r runner.Runner, rootfs, machine, intuneHome, containerHome string, sockets []BindMount) error {
 	args := append([]string{"systemd-nspawn"}, BuildBootArgs(rootfs, machine, intuneHome, containerHome, sockets)...)


### PR DESCRIPTION
## Summary

Adds `intuneme open edge` and `intuneme open portal` subcommands that launch GUI apps inside the running container without opening a terminal window.

## Problem

There was no way to launch container apps (Edge, Intune Portal) from outside the container — e.g. from a `.desktop` file, GNOME extension button, or shell alias — without first dropping into `intuneme shell`.

## Approach

`machinectl shell` requires a PTY and silently exits 0 without starting a session when run non-interactively (stdin/stdout redirected). Instead, `Exec()` uses `nsenter` to enter the container's namespaces directly via the leader PID, then runs the app as the correct user with all required environment variables set explicitly:

- `DISPLAY`, `XAUTHORITY` — X11 display access
- `WAYLAND_DISPLAY` — Wayland socket
- `PIPEWIRE_REMOTE`, `PULSE_SERVER` — audio
- `XDG_RUNTIME_DIR`, `DBUS_SESSION_BUS_ADDRESS` — user session bus

The app is launched with `nohup ... &` so the call returns immediately.

## New API in `internal/nspawn`

- `LeaderPID(r, machine)` — retrieves container init PID via `machinectl show -p Leader --value`
- `Exec(r, machine, user, uid, command)` — launches a command non-interactively via `sudo nsenter`

## Testing

Tested on Bluefin (Fedora-based, SELinux enforcing). Both `intuneme open edge` and `intuneme open portal` launch and display windows correctly.