### PR TITLE
Fix repository logic

### DIFF
--- a/ubuntu-intune/build_files/build
+++ b/ubuntu-intune/build_files/build
@@ -14,8 +14,21 @@ curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microso
 install -o root -g root -m 644 microsoft.gpg /usr/share/keyrings
 rm microsoft.gpg
 
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/microsoft.gpg] https://packages.microsoft.com/ubuntu/$(lsb_release -rs)/prod $(lsb_release -cs) main" > /etc/apt/sources.list.d/microsoft-ubuntu-$(lsb_release -cs)-prod.list
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/edge stable main" > /etc/apt/sources.list.d/microsoft-edge.list
+tee /etc/apt/sources.list.d/microsoft.sources > /dev/null << REPOEOF
+Types: deb
+URIs: https://packages.microsoft.com/ubuntu/$(lsb_release -rs)/prod
+Suites: $(lsb_release -cs)
+Components: main
+Architectures: $(dpkg --print-architecture)
+Signed-By: /usr/share/keyrings/microsoft.gpg
+
+Types: deb
+URIs: https://packages.microsoft.com/repos/edge
+Suites: stable
+Components: main
+Architectures: $(dpkg --print-architecture)
+Signed-By: /usr/share/keyrings/microsoft.gpg
+REPOEOF
 apt update -y
 
 # Remove no longer needed packages
@@ -45,6 +58,16 @@ apt install -y \
   libpulse0 \
   sudo \
   cracklib-runtime
+
+# Microsoft Edge install adds a redundant .list file; remove it
+if [[ -f /etc/apt/sources.list.d/microsoft-edge.list ]]; then
+  rm /etc/apt/sources.list.d/microsoft-edge.list
+fi
+
+# Remove repo_reenable_on_distupgrade option that Edge adds
+if [[ -f /etc/default/microsoft-edge ]]; then
+  sed -i 's/^repo_reenable_on_distupgrade=true$/repo_reenable_on_distupgrade=false/' /etc/default/microsoft-edge
+fi
 
 # Intune needs fixes to install properly
 # Install its dependencies first


### PR DESCRIPTION
The deb package for `microsoft-edge-stable` creates its own `.list` file under `/etc/apt/sources.list.d` which overwrites the `.list` file that's created by the `build` script, thus rendering the package repository inoperative, because the repository file created by Edge is not using the same key file and therefore the repository appears unsigned. This is easily remedied by simply using a different filename.

However, I've also taken the liberty of transitioning the repository information to the newer DEB822-compliant format, which is mandatory for Ubuntu >= 26.04, and recommended for Ubuntu >= 24.04. In fact, ever since Ubuntu 25.10, all `.list` files in `/etc/apt/sources.list.d` are automatically converted into DEB822-compliant repository files, ending with `.sources`. As with the old format, you can have multiple repositories defined per file, which I've done for this transition and simply named the file `microsoft.sources`, which keeps all Microsoft-related repositories grouped in a single file.

I've also added further logic which removes the repository `microsoft-edge-stable` is adding via a `cron.daily` trigger, and permanently disabled all related logic via its `/etc/default` shell include.