### PR TITLE
fix: Pass explicit command to docker/podman create for images without CMD

### DIFF
--- a/internal/puller/puller.go
+++ b/internal/puller/puller.go
@@ -57,8 +57,9 @@ func (p *PodmanPuller) PullAndExtract(r runner.Runner, image string, rootfsPath 
 		return fmt.Errorf("podman pull failed: %w\n%s", err, out)
 	}
 
-	// Create a temporary container to export
-	out, err = r.Run("podman", "create", "--name", "intuneme-extract", image)
+	// Create a temporary container to export (command is required but never
+	// run — the container is only created so we can export its filesystem)
+	out, err = r.Run("podman", "create", "--name", "intuneme-extract", image, "/bin/true")
 	if err != nil {
 		return fmt.Errorf("podman create failed: %w\n%s", err, out)
 	}
@@ -130,8 +131,9 @@ func (p *DockerPuller) PullAndExtract(r runner.Runner, image string, rootfsPath 
 		return fmt.Errorf("docker pull failed: %w\n%s", err, out)
 	}
 
-	// Create a temporary container to export
-	out, err = r.Run("docker", "create", "--name", "intuneme-extract", image)
+	// Create a temporary container to export (command is required but never
+	// run — the container is only created so we can export its filesystem)
+	out, err = r.Run("docker", "create", "--name", "intuneme-extract", image, "/bin/true")
 	if err != nil {
 		return fmt.Errorf("docker create failed: %w\n%s", err, out)
 	}

--- a/internal/puller/puller_test.go
+++ b/internal/puller/puller_test.go
@@ -98,7 +98,7 @@ func TestPodmanPullAndExtract(t *testing.T) {
 	// Expected commands:
 	// 1. podman rm intuneme-extract (cleanup)
 	// 2. podman pull <image>
-	// 3. podman create --name intuneme-extract <image>
+	// 3. podman create --name intuneme-extract <image> /bin/true
 	// 4. podman export -o <tmp> intuneme-extract
 	// 5. sudo tar -xf <tmp> -C <rootfs>
 	// 6. podman rm intuneme-extract
@@ -108,8 +108,8 @@ func TestPodmanPullAndExtract(t *testing.T) {
 	if !strings.Contains(r.commands[1], "podman pull") {
 		t.Errorf("cmd[1]: expected podman pull, got: %s", r.commands[1])
 	}
-	if !strings.Contains(r.commands[2], "podman create") {
-		t.Errorf("cmd[2]: expected podman create, got: %s", r.commands[2])
+	if !strings.Contains(r.commands[2], "podman create") || !strings.Contains(r.commands[2], "/bin/true") {
+		t.Errorf("cmd[2]: expected podman create with /bin/true, got: %s", r.commands[2])
 	}
 	if !strings.Contains(r.commands[3], "podman export") {
 		t.Errorf("cmd[3]: expected podman export, got: %s", r.commands[3])
@@ -162,7 +162,7 @@ func TestDockerPullAndExtract(t *testing.T) {
 	// Expected commands:
 	// 1. docker rm intuneme-extract (cleanup)
 	// 2. docker pull <image>
-	// 3. docker create --name intuneme-extract <image>
+	// 3. docker create --name intuneme-extract <image> /bin/true
 	// 4. docker export -o <tmp> intuneme-extract
 	// 5. sudo tar -xf <tmp> -C <rootfs>
 	// 6. docker rm intuneme-extract
@@ -172,8 +172,8 @@ func TestDockerPullAndExtract(t *testing.T) {
 	if !strings.Contains(r.commands[1], "docker pull") {
 		t.Errorf("cmd[1]: expected docker pull, got: %s", r.commands[1])
 	}
-	if !strings.Contains(r.commands[2], "docker create") {
-		t.Errorf("cmd[2]: expected docker create, got: %s", r.commands[2])
+	if !strings.Contains(r.commands[2], "docker create") || !strings.Contains(r.commands[2], "/bin/true") {
+		t.Errorf("cmd[2]: expected docker create with /bin/true, got: %s", r.commands[2])
 	}
 	if !strings.Contains(r.commands[3], "docker export") {
 		t.Errorf("cmd[3]: expected docker export, got: %s", r.commands[3])


### PR DESCRIPTION
## Summary
- Fixes `intuneme init` failing with "no command specified" when using Docker or Podman (#51)
- The container image has no `CMD`/`ENTRYPOINT` (by design — it's for systemd-nspawn boot), but `docker create` / `podman create` require one even when the container is never started
- Adds `/bin/true` as a no-op command to both `create` calls in the puller

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] Lint clean (`make lint`)
- [ ] Manual: `intuneme init` with Docker on a system without prior rootfs
- [ ] Manual: `intuneme init` with Podman on a system without prior rootfs

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)