### PR TITLE
Fix nspawn unit resolution

### DIFF
--- a/internal/nspawn/nspawn.go
+++ b/internal/nspawn/nspawn.go
@@ -172,18 +172,28 @@ func BuildShellArgs(machine, user string) []string {
 	return []string{"shell", fmt.Sprintf("%s@%s", user, machine), "/bin/bash", "--login"}
 }
 
-// LeaderPID returns the PID of the container's init process (Leader) as reported
-// by machinectl, which is used to enter the container's namespaces via nsenter.
-func LeaderPID(r runner.Runner, machine string) (string, error) {
-	out, err := r.Run("machinectl", "show", machine, "-p", "Leader", "--value")
+func machinectlValue(r runner.Runner, machine, property string) (string, error) {
+	out, err := r.Run("machinectl", "show", machine, "-p", property, "--value")
 	if err != nil {
 		return "", fmt.Errorf("machinectl show failed: %w", err)
 	}
-	pid := strings.TrimSpace(string(out))
-	if pid == "" || pid == "0" {
-		return "", fmt.Errorf("container %s is not running", machine)
+
+	value := strings.TrimSpace(string(out))
+	if value == "" || value == "0" {
+		return "", fmt.Errorf("container %s property %s is unavailable", machine, property)
 	}
-	return pid, nil
+	return value, nil
+}
+
+// LeaderPID returns the PID of the container's init process (Leader) as reported
+// by machinectl, which is used to enter the container's namespaces via nsenter.
+func LeaderPID(r runner.Runner, machine string) (string, error) {
+	return machinectlValue(r, machine, "Leader")
+}
+
+// MachineUnit returns the systemd unit currently backing the machine.
+func MachineUnit(r runner.Runner, machine string) (string, error) {
+	return machinectlValue(r, machine, "Unit")
 }
 
 // Exec runs a command non-interactively inside the container as the given user.

--- a/internal/nspawn/nspawn_test.go
+++ b/internal/nspawn/nspawn_test.go
@@ -10,16 +10,29 @@ import (
 type mockRunner struct {
 	commands    []string
 	fileContent string // captured from the source file in the last "install" command
+	outputs     map[string]string
+	errors      map[string]error
 }
 
 func (m *mockRunner) Run(name string, args ...string) ([]byte, error) {
-	m.commands = append(m.commands, name+" "+strings.Join(args, " "))
+	cmd := name + " " + strings.Join(args, " ")
+	m.commands = append(m.commands, cmd)
 	// Capture the temp file content before WriteDisplayMarker deletes it.
 	// sudo install <flags> <src> <dst> — src is the second-to-last arg.
 	if name == "sudo" && len(args) >= 4 && args[0] == "install" {
 		src := args[len(args)-2]
 		if data, err := os.ReadFile(src); err == nil {
 			m.fileContent = string(data)
+		}
+	}
+	for prefix, err := range m.errors {
+		if strings.HasPrefix(cmd, prefix) {
+			return nil, err
+		}
+	}
+	for prefix, out := range m.outputs {
+		if strings.HasPrefix(cmd, prefix) {
+			return []byte(out), nil
 		}
 	}
 	return nil, nil
@@ -101,6 +114,38 @@ func TestBuildShellArgs(t *testing.T) {
 	}
 	if !strings.Contains(joined, "/bin/bash --login") {
 		t.Errorf("missing login shell in: %s", joined)
+	}
+}
+
+func TestLeaderPID(t *testing.T) {
+	r := &mockRunner{
+		outputs: map[string]string{
+			"machinectl show intuneme -p Leader --value": "12345\n",
+		},
+	}
+
+	pid, err := LeaderPID(r, "intuneme")
+	if err != nil {
+		t.Fatalf("LeaderPID failed: %v", err)
+	}
+	if pid != "12345" {
+		t.Fatalf("LeaderPID() = %q, want %q", pid, "12345")
+	}
+}
+
+func TestMachineUnit(t *testing.T) {
+	r := &mockRunner{
+		outputs: map[string]string{
+			"machinectl show intuneme -p Unit --value": "intuneme.scope\n",
+		},
+	}
+
+	unit, err := MachineUnit(r, "intuneme")
+	if err != nil {
+		t.Fatalf("MachineUnit failed: %v", err)
+	}
+	if unit != "intuneme.scope" {
+		t.Fatalf("MachineUnit() = %q, want %q", unit, "intuneme.scope")
 	}
 }
 

--- a/internal/udev/udev.go
+++ b/internal/udev/udev.go
@@ -236,6 +236,10 @@ func ForwardDevice(r runner.Runner, machine, devnode string) error {
 	if err != nil {
 		return err
 	}
+	unit, err := nspawn.MachineUnit(r, machine)
+	if err != nil {
+		return err
+	}
 
 	// Get major:minor of the device.
 	out, err := r.Run("stat", "-c", "0x%t 0x%T", devnode)
@@ -251,7 +255,7 @@ func ForwardDevice(r runner.Runner, machine, devnode string) error {
 	// Allow the device in the container's cgroup. DevicePolicy=auto preserves
 	// the existing nspawn device policy and adds our device on top.
 	if _, err := r.Run("sudo", "systemctl", "set-property",
-		fmt.Sprintf("machine-%s.scope", machine),
+		unit,
 		"DevicePolicy=auto",
 		fmt.Sprintf("DeviceAllow=%s rwm", devnode)); err != nil {
 		return fmt.Errorf("cgroup DeviceAllow for %s: %w", devnode, err)

--- a/internal/udev/udev_test.go
+++ b/internal/udev/udev_test.go
@@ -224,7 +224,8 @@ func TestScriptPath(t *testing.T) {
 
 func TestForwardDevice(t *testing.T) {
 	r := newMockRunner()
-	r.outputs["machinectl show"] = "12345"
+	r.outputs["machinectl show intuneme -p Leader --value"] = "12345"
+	r.outputs["machinectl show intuneme -p Unit --value"] = "intuneme.scope"
 	r.outputs["stat -c"] = "0xbd 0x9"
 
 	err := ForwardDevice(r, "intuneme", "/dev/bus/usb/003/009")
@@ -233,7 +234,7 @@ func TestForwardDevice(t *testing.T) {
 	}
 
 	// Should set cgroup for USB devices too (runtime DeviceAllow is additive).
-	if !r.hasCommand("sudo systemctl set-property machine-intuneme.scope DevicePolicy=auto DeviceAllow=/dev/bus/usb/003/009 rwm") {
+	if !r.hasCommand("sudo systemctl set-property intuneme.scope DevicePolicy=auto DeviceAllow=/dev/bus/usb/003/009 rwm") {
 		t.Error("missing cgroup set-property for USB device")
 	}
 
@@ -245,7 +246,8 @@ func TestForwardDevice(t *testing.T) {
 
 func TestForwardDeviceHidraw(t *testing.T) {
 	r := newMockRunner()
-	r.outputs["machinectl show"] = "12345"
+	r.outputs["machinectl show intuneme -p Leader --value"] = "12345"
+	r.outputs["machinectl show intuneme -p Unit --value"] = "intuneme.scope"
 	r.outputs["stat -c"] = "0xa 0x3"
 
 	err := ForwardDevice(r, "intuneme", "/dev/hidraw3")
@@ -254,7 +256,7 @@ func TestForwardDeviceHidraw(t *testing.T) {
 	}
 
 	// Should set cgroup for hidraw device.
-	if !r.hasCommand("sudo systemctl set-property machine-intuneme.scope DevicePolicy=auto DeviceAllow=/dev/hidraw3 rwm") {
+	if !r.hasCommand("sudo systemctl set-property intuneme.scope DevicePolicy=auto DeviceAllow=/dev/hidraw3 rwm") {
 		t.Error("missing cgroup set-property for hidraw")
 	}
 }
@@ -271,7 +273,8 @@ func TestForwardDeviceContainerNotRunning(t *testing.T) {
 
 func TestForwardDeviceVideoPermissions(t *testing.T) {
 	r := newMockRunner()
-	r.outputs["machinectl show"] = "12345"
+	r.outputs["machinectl show intuneme -p Leader --value"] = "12345"
+	r.outputs["machinectl show intuneme -p Unit --value"] = "intuneme.scope"
 	r.outputs["stat -c"] = "0x51 0x0"
 
 	err := ForwardDevice(r, "intuneme", "/dev/video0")
@@ -294,7 +297,8 @@ func TestForwardDeviceVideoPermissions(t *testing.T) {
 
 func TestForwardDeviceMediaPermissions(t *testing.T) {
 	r := newMockRunner()
-	r.outputs["machinectl show"] = "12345"
+	r.outputs["machinectl show intuneme -p Leader --value"] = "12345"
+	r.outputs["machinectl show intuneme -p Unit --value"] = "intuneme.scope"
 	r.outputs["stat -c"] = "0x51 0x1"
 
 	err := ForwardDevice(r, "intuneme", "/dev/media0")


### PR DESCRIPTION
## 1. Description

`intuneme` hardcoded the hotplug cgroup target as `machine-<name>.scope` when forwarding USB/video devices into the running `systemd-nspawn` container.

On newer systemd, especially `v259+`, that assumption is no longer reliable. A directly started nspawn container can be backed by a different unit name such as `<name>.scope`, so device forwarding fails when `systemctl set-property` targets the wrong unit.

## 2. Reprosteps

1. Use a host with newer systemd (for example Arch with `systemd v259+`).
2. Start the container with `intuneme start`.
3. Check the real backing unit:
   ```bash
   machinectl show intuneme -p Unit --value
   ```
4. Observe it returns something like:
   ```bash
   intuneme.scope
   ```
   instead of:
   ```bash
   machine-intuneme.scope
   ```
5. Trigger device forwarding, for example by starting with an attached YubiKey/webcam or hotplugging one.
6. The old code tries:
   ```bash
   sudo systemctl set-property machine-intuneme.scope DevicePolicy=auto DeviceAllow=...
   ```
7. That fails because the unit name is wrong.

## 3. Root cause analysis

The repo assumed an older/common systemd naming pattern and encoded it directly:

```go
fmt.Sprintf("machine-%s.scope", machine)
```

https://github.com/systemd/systemd/commit/814db2ae79
But upstream systemd changed the direct `systemd-nspawn` path. In systemd commit `814db2ae79` (`v259`), nspawn switched to always allocating the scope itself and then registering it, rather than relying on machined to create the scope under older behavior.

As a result, the real backing unit must be treated as runtime data, not guessed from the machine name.

## 4. Fixes

- Added a helper that resolves the real unit dynamically:
  ```bash
  machinectl show <machine> -p Unit --value
  ```
- Updated hotplug forwarding to call `systemctl set-property` on that resolved unit instead of hardcoding `machine-<name>.scope`.
- Updated the affected tests to match the new runtime unit resolution behavior.