### PR TITLE
fix: Run session setup on nsenter launch path so Edge can authenticate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,8 @@ The repository has two main components:
 
 A sudoers rule at `/etc/sudoers.d/intuneme-exec` (installed by `intuneme init`, persists across start/stop, removed by `intuneme destroy`) makes the nsenter command passwordless, so the GNOME extension can launch apps without a terminal for sudo prompts. The `start` command reinstalls it idempotently if missing (handles upgrades from older versions).
 
+**Session setup runs on the nsenter path too.** The nsenter shell is *non-login*, so it never sources `/etc/profile.d`. `nspawn.Exec()` therefore runs `/usr/local/bin/intuneme-session-setup` (the shared script that `/etc/profile.d/intuneme.sh` also sources) before launching the app. That script pushes `DISPLAY`/`XAUTHORITY` into the **D-Bus activation environment** (`dbus-update-activation-environment`) and unlocks gnome-keyring. This is mandatory: the Microsoft identity broker is a GTK app that the session D-Bus daemon activates on demand — without a display in the activation environment it dies on startup (`cannot open display`) and **Edge can't authenticate**. `start` reinstalls the script if missing. See `yeti/OVERVIEW.md` → "Session Setup".
+
 ## Before committing
 
 Always run `make fmt` and `make lint` before committing. Fix any lint errors before creating commits.

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -159,6 +159,18 @@ var startCmd = &cobra.Command{
 			}
 		}
 
+		// Ensure the shared session-setup script exists. Normally installed by
+		// init; reinstall here if missing (upgrade from a version before it
+		// existed). Without it, GUI apps launched via the GNOME extension would
+		// have no DISPLAY in the broker's environment and couldn't authenticate.
+		if !provision.SessionScriptsInstalled(cfg.RootfsPath) {
+			if err := provision.InstallSessionScripts(r, cfg.RootfsPath); err != nil {
+				rep.Message("Warning: failed to install session setup script (auth may fail when launching from the extension): %v", err)
+			} else if clix.Verbose {
+				rep.Message("Installed session setup script.")
+			}
+		}
+
 		// Ensure the container user is in groups that depend on packages
 		// installed inside the image (currently plugdev for pcscd access).
 		// Self-heals containers provisioned before plugdev was in baseGroups.

--- a/internal/nspawn/nspawn.go
+++ b/internal/nspawn/nspawn.go
@@ -219,6 +219,13 @@ if [ -d /run/host-nvidia ]; then
     export __NV_PRIME_RENDER_OFFLOAD=1
     export __GLX_VENDOR_LIBRARY_NAME=nvidia
 fi
+# Initialize the session the same way an interactive login would. This is a
+# non-login shell, so /etc/profile.d is never sourced; without this the D-Bus
+# activation environment lacks DISPLAY/XAUTHORITY and the GTK identity broker
+# crashes on activation (Edge can't authenticate), and the keyring stays locked.
+if [ -x /usr/local/bin/intuneme-session-setup ]; then
+    /usr/local/bin/intuneme-session-setup
+fi
 nohup %s >/dev/null 2>&1 &`,
 		display, uidStr, uidStr, command,
 	)

--- a/internal/provision/intuneme-profile.sh
+++ b/internal/provision/intuneme-profile.sh
@@ -1,79 +1,14 @@
 #!/bin/bash
-# /etc/profile.d/intuneme.sh — runs on login in the intuneme container.
-# Sets display/audio environment, imports into systemd user session,
-# and initializes gnome-keyring on first login after boot.
-
-# Display environment — read host display from marker written by intuneme start
-if [ -f /etc/intuneme-host-display ]; then
-    . /etc/intuneme-host-display
-    export DISPLAY
-else
-    export DISPLAY=:0
-fi
-export NO_AT_BRIDGE=1
-export GTK_A11Y=none
-export PATH="/opt/microsoft/intune/bin:/opt/microsoft/microsoft-azurevpnclient:$PATH"
-
-# X11 auth — bind-mounted from host at /run/host-xauthority
-if [ -f /run/host-xauthority ]; then
-    export XAUTHORITY=/run/host-xauthority
-fi
-
-# Import into systemd user session so user services (broker) see them
-systemctl --user import-environment DISPLAY XAUTHORITY PATH NO_AT_BRIDGE GTK_A11Y 2>/dev/null
-
-# Wayland socket (bind-mounted from host at /run/host-wayland)
-if [ -S /run/host-wayland ]; then
-    export WAYLAND_DISPLAY=/run/host-wayland
-    systemctl --user import-environment WAYLAND_DISPLAY 2>/dev/null
-fi
-
-# PipeWire socket (bind-mounted from host at /run/host-pipewire)
-if [ -S /run/host-pipewire ]; then
-    export PIPEWIRE_REMOTE=/run/host-pipewire
-    systemctl --user import-environment PIPEWIRE_REMOTE 2>/dev/null
-fi
-
-# PulseAudio socket (bind-mounted from host at /run/host-pulse)
-if [ -S /run/host-pulse ]; then
-    export PULSE_SERVER=unix:/run/host-pulse
-    systemctl --user import-environment PULSE_SERVER 2>/dev/null
-fi
-
-# Nvidia GPU (libraries symlinked from host by intuneme start)
-if [ -d /run/host-nvidia ]; then
-    export __NV_PRIME_RENDER_OFFLOAD=1
-    export __GLX_VENDOR_LIBRARY_NAME=nvidia
-    systemctl --user import-environment __NV_PRIME_RENDER_OFFLOAD __GLX_VENDOR_LIBRARY_NAME 2>/dev/null
-fi
-
-# Initialize gnome-keyring once per boot.
-# The keyring must be unlocked for microsoft-identity-broker to store credentials.
-# Marker lives in /tmp (tmpfs) so it resets on every container boot — the keyring
-# dir is on the persistent bind-mounted home and would survive reboots.
-_keyring_dir="$HOME/.local/share/keyrings"
-_keyring_init_marker="/tmp/.intuneme-keyring-init-done"
-
-if [ ! -f "$_keyring_init_marker" ]; then
-    mkdir -p "$_keyring_dir"
-    if [ ! -f "$_keyring_dir/default" ]; then
-        echo "login" > "$_keyring_dir/default"
-    fi
-    echo "" | gnome-keyring-daemon --replace --unlock --components=secrets,pkcs11 -d 2>/dev/null
-    sleep 1
-    # Store a test secret to force creation of the default collection.
-    # Without this, ReadAlias("default") returns "/" and the broker can't store credentials.
-    if ! secret-tool lookup _keyring_init _keyring_init >/dev/null 2>&1; then
-        echo "init" | secret-tool store --label="Keyring Init" _keyring_init _keyring_init 2>/dev/null
-    fi
-    touch "$_keyring_init_marker"
-    # Restart brokers so they pick up the now-initialized keyring.
-    # They start before login and fail with storage_keyring_write_failure.
-    systemctl --user restart microsoft-identity-broker.service 2>/dev/null
-    sudo systemctl restart microsoft-identity-device-broker.service 2>/dev/null
-fi
-
-# Start intune agent timer if not running
-if ! systemctl -q --user is-active intune-agent.timer 2>/dev/null; then
-    systemctl --user start intune-agent.timer 2>/dev/null
+# /etc/profile.d/intuneme.sh — runs on interactive login in the container.
+#
+# All session initialization (display/audio env, D-Bus activation environment,
+# gnome-keyring unlock, intune agent timer) lives in the shared script below so
+# that the login path and the non-login nsenter launch path (nspawn.Exec, used
+# by the GNOME extension) initialize the session identically. See that script
+# for the rationale.
+#
+# Sourced — not executed — so the exported env vars land in the login shell too.
+if [ -r /usr/local/bin/intuneme-session-setup ]; then
+    # shellcheck source=/dev/null
+    . /usr/local/bin/intuneme-session-setup
 fi

--- a/internal/provision/intuneme-session-setup.sh
+++ b/internal/provision/intuneme-session-setup.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# /usr/local/bin/intuneme-session-setup — shared container session initialization.
+#
+# This is invoked from BOTH session-entry paths so they behave identically:
+#   - /etc/profile.d/intuneme.sh sources it on interactive login (machinectl shell).
+#   - nspawn.Exec() runs it before launching a GUI app via nsenter (the path the
+#     GNOME extension uses). That path is a NON-login shell, so without this it
+#     would never source /etc/profile.d and the steps below would be skipped.
+#
+# Why this matters: the Microsoft identity broker is a GTK app that the session
+# D-Bus daemon activates on demand. It only inherits DISPLAY/XAUTHORITY if those
+# were pushed into the D-Bus *activation* environment — otherwise it dies on
+# startup with "cannot open display" and Edge can't authenticate. It also needs
+# an unlocked gnome-keyring to read/write tokens.
+#
+# Safe to source or execute, and idempotent: env propagation runs every time,
+# keyring init runs at most once per boot.
+
+# Ensure we can reach the user session bus even from a non-login shell.
+: "${XDG_RUNTIME_DIR:=/run/user/$(id -u)}"
+export XDG_RUNTIME_DIR
+: "${DBUS_SESSION_BUS_ADDRESS:=unix:path=${XDG_RUNTIME_DIR}/bus}"
+export DBUS_SESSION_BUS_ADDRESS
+
+# Display environment — host DISPLAY written by `intuneme start` into a marker.
+if [ -f /etc/intuneme-host-display ]; then
+    # shellcheck source=/dev/null
+    . /etc/intuneme-host-display
+    export DISPLAY
+else
+    export DISPLAY=:0
+fi
+export NO_AT_BRIDGE=1
+export GTK_A11Y=none
+export PATH="/opt/microsoft/intune/bin:/opt/microsoft/microsoft-azurevpnclient:$PATH"
+
+# X11 auth — bind-mounted from host at /run/host-xauthority
+if [ -f /run/host-xauthority ]; then
+    export XAUTHORITY=/run/host-xauthority
+fi
+
+# Wayland / PipeWire / PulseAudio sockets (bind-mounted from host)
+if [ -S /run/host-wayland ]; then
+    export WAYLAND_DISPLAY=/run/host-wayland
+fi
+if [ -S /run/host-pipewire ]; then
+    export PIPEWIRE_REMOTE=/run/host-pipewire
+fi
+if [ -S /run/host-pulse ]; then
+    export PULSE_SERVER=unix:/run/host-pulse
+fi
+
+# Nvidia GPU (libraries symlinked from host by intuneme start)
+if [ -d /run/host-nvidia ]; then
+    export __NV_PRIME_RENDER_OFFLOAD=1
+    export __GLX_VENDOR_LIBRARY_NAME=nvidia
+fi
+
+# Propagate the environment to the systemd user manager AND the D-Bus activation
+# environment. The latter is what D-Bus-activated services (the identity broker)
+# inherit — without it the broker has no DISPLAY and crashes on activation.
+_env_vars="DISPLAY XAUTHORITY NO_AT_BRIDGE GTK_A11Y PATH WAYLAND_DISPLAY \
+PIPEWIRE_REMOTE PULSE_SERVER __NV_PRIME_RENDER_OFFLOAD __GLX_VENDOR_LIBRARY_NAME"
+# Only pass variables that are actually set, so we don't clear them.
+_set_vars=""
+for _v in $_env_vars; do
+    [ -n "${!_v+x}" ] && _set_vars="$_set_vars $_v"
+done
+if [ -n "$_set_vars" ]; then
+    # shellcheck disable=SC2086
+    systemctl --user import-environment $_set_vars 2>/dev/null
+    # shellcheck disable=SC2086
+    dbus-update-activation-environment --systemd $_set_vars 2>/dev/null
+fi
+
+# Initialize gnome-keyring once per boot. The keyring must be unlocked for the
+# identity broker to store/read credentials. Marker lives in /tmp (tmpfs) so it
+# resets every boot; the keyring dir is on the persistent bind-mounted home.
+_keyring_dir="$HOME/.local/share/keyrings"
+_keyring_marker="/tmp/.intuneme-keyring-init-done"
+
+if [ ! -f "$_keyring_marker" ]; then
+    mkdir -p "$_keyring_dir"
+    [ -f "$_keyring_dir/default" ] || echo "login" > "$_keyring_dir/default"
+
+    # Is the login collection already unlocked? If so, leave the running daemon
+    # alone — don't disrupt an in-use keyring.
+    _locked=$(busctl --user get-property org.freedesktop.secrets \
+        /org/freedesktop/secrets/collection/login \
+        org.freedesktop.Secret.Collection Locked 2>/dev/null)
+
+    if [ "$_locked" != "b false" ]; then
+        # Reliable unlock: the well-known org.freedesktop.secrets name is held by
+        # whichever gnome-keyring daemon claimed it first (often the systemd
+        # socket-activated one). A `--replace --unlock` daemon does NOT take that
+        # name, so its unlock never reaches the daemon the broker talks to.
+        # Kill ALL keyring daemons (matched by truncated comm to avoid a pkill -f
+        # self-match) and start exactly one that owns the service and is unlocked.
+        pkill -u "$(id -u)" -x gnome-keyring-d 2>/dev/null
+        sleep 1
+        # `echo ""` sends a newline = real empty-string password (creates/unlocks
+        # the login keyring). `printf ""` would send EOF = "no password" and do
+        # nothing. The container's login keyring uses an empty password.
+        echo "" | gnome-keyring-daemon --unlock --components=secrets,pkcs11 -d 2>/dev/null
+        sleep 1
+    fi
+
+    # Force-create the default collection so ReadAlias("default") resolves and the
+    # broker can store credentials. A no-op if it already exists.
+    if ! secret-tool lookup _keyring_init _keyring_init >/dev/null 2>&1; then
+        echo "init" | secret-tool store --label="Keyring Init" _keyring_init _keyring_init 2>/dev/null
+    fi
+
+    touch "$_keyring_marker"
+
+    # Restart the system device broker so it re-reads the now-initialized keyring.
+    # The user-session identity broker is D-Bus-activated (not a systemd unit), so
+    # it is NOT restarted here — it re-activates with a fresh process, and now
+    # working environment, on the next call from Edge.
+    sudo systemctl restart microsoft-identity-device-broker.service 2>/dev/null
+fi
+
+# Start the intune agent timer if it isn't already running.
+if ! systemctl -q --user is-active intune-agent.timer 2>/dev/null; then
+    systemctl --user start intune-agent.timer 2>/dev/null
+fi

--- a/internal/provision/provision.go
+++ b/internal/provision/provision.go
@@ -18,6 +18,14 @@ import (
 //go:embed intuneme-profile.sh
 var intuneProfileScript []byte
 
+//go:embed intuneme-session-setup.sh
+var intuneSessionSetupScript []byte
+
+// sessionSetupPath is the container-side install location of the shared session
+// setup script. It is referenced from /etc/profile.d/intuneme.sh (login path)
+// and from nspawn.Exec (the non-login launch path).
+const sessionSetupPath = "usr/local/bin/intuneme-session-setup"
+
 // sudoMkdirAll creates directories with sudo.
 func sudoMkdirAll(r runner.Runner, path string) error {
 	_, err := r.Run("sudo", "mkdir", "-p", path)
@@ -77,13 +85,9 @@ WantedBy=multi-user.target
 		return fmt.Errorf("symlink fix-home-ownership.service: %w", err)
 	}
 
-	// Install profile.d/intuneme.sh — sets display/audio env on login
-	profileDir := filepath.Join(rootfsPath, "etc", "profile.d")
-	if err := sudoMkdirAll(r, profileDir); err != nil {
-		return fmt.Errorf("mkdir profile.d: %w", err)
-	}
-	if err := sudo.WriteFile(r, filepath.Join(profileDir, "intuneme.sh"), intuneProfileScript, 0755); err != nil {
-		return fmt.Errorf("write profile.d/intuneme.sh: %w", err)
+	// Install the session setup scripts (shared script + profile.d entry point).
+	if err := InstallSessionScripts(r, rootfsPath); err != nil {
+		return err
 	}
 
 	// Passwordless sudo for the container user
@@ -97,6 +101,37 @@ WantedBy=multi-user.target
 	}
 
 	return nil
+}
+
+// InstallSessionScripts writes the shared session-setup script and the
+// profile.d entry point that sources it. Both the interactive login path and
+// the nsenter launch path (nspawn.Exec) rely on the shared script existing at
+// /usr/local/bin/intuneme-session-setup. Idempotent — safe to re-run.
+func InstallSessionScripts(r runner.Runner, rootfsPath string) error {
+	binDir := filepath.Join(rootfsPath, filepath.Dir(sessionSetupPath))
+	if err := sudoMkdirAll(r, binDir); err != nil {
+		return fmt.Errorf("mkdir %s: %w", binDir, err)
+	}
+	if err := sudo.WriteFile(r, filepath.Join(rootfsPath, sessionSetupPath), intuneSessionSetupScript, 0755); err != nil {
+		return fmt.Errorf("write %s: %w", sessionSetupPath, err)
+	}
+
+	profileDir := filepath.Join(rootfsPath, "etc", "profile.d")
+	if err := sudoMkdirAll(r, profileDir); err != nil {
+		return fmt.Errorf("mkdir profile.d: %w", err)
+	}
+	if err := sudo.WriteFile(r, filepath.Join(profileDir, "intuneme.sh"), intuneProfileScript, 0755); err != nil {
+		return fmt.Errorf("write profile.d/intuneme.sh: %w", err)
+	}
+	return nil
+}
+
+// SessionScriptsInstalled reports whether the shared session-setup script is
+// present in the rootfs. Used by `start` to self-heal containers provisioned
+// before the script existed.
+func SessionScriptsInstalled(rootfsPath string) bool {
+	_, err := os.Stat(filepath.Join(rootfsPath, sessionSetupPath))
+	return err == nil
 }
 
 // SetContainerPassword sets the user's password inside the container via chpasswd.

--- a/internal/provision/provision_test.go
+++ b/internal/provision/provision_test.go
@@ -80,6 +80,65 @@ func TestWriteFixups(t *testing.T) {
 	}
 }
 
+func TestInstallSessionScripts(t *testing.T) {
+	r := &mockRunner{}
+	if err := InstallSessionScripts(r, "/tmp/test-rootfs"); err != nil {
+		t.Fatalf("InstallSessionScripts error: %v", err)
+	}
+	allCmds := strings.Join(r.commands, "\n")
+
+	// Both the shared script (in usr/local/bin) and the profile.d entry point
+	// must be written.
+	for _, want := range []string{
+		"usr/local/bin/intuneme-session-setup",
+		"etc/profile.d/intuneme.sh",
+	} {
+		if !strings.Contains(allCmds, want) {
+			t.Errorf("expected command referencing %q, not found in:\n%s", want, allCmds)
+		}
+	}
+}
+
+func TestSessionScriptsInstalled(t *testing.T) {
+	rootfs := t.TempDir()
+	if SessionScriptsInstalled(rootfs) {
+		t.Fatal("SessionScriptsInstalled = true before install")
+	}
+
+	scriptPath := filepath.Join(rootfs, sessionSetupPath)
+	if err := os.MkdirAll(filepath.Dir(scriptPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/bash\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if !SessionScriptsInstalled(rootfs) {
+		t.Error("SessionScriptsInstalled = false after install")
+	}
+}
+
+// TestSessionSetupScriptContent guards the two fixes that make the broker work
+// on the non-login launch path: pushing env into the D-Bus activation
+// environment, and unlocking the keyring with a real empty password.
+func TestSessionSetupScriptContent(t *testing.T) {
+	script := string(intuneSessionSetupScript)
+	for _, want := range []string{
+		"dbus-update-activation-environment", // broker inherits DISPLAY/XAUTHORITY
+		"import-environment",
+		`echo "" | gnome-keyring-daemon --unlock`, // empty pw via newline, not EOF
+		"pkill -u", // reliable single-daemon unlock
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("session-setup script missing required snippet %q", want)
+		}
+	}
+	// The broken restart of the (D-Bus-activated, not a unit) user broker must
+	// not be reintroduced.
+	if strings.Contains(script, "restart microsoft-identity-broker.service") {
+		t.Error("session-setup must not restart the user identity broker (it is D-Bus-activated, not a systemd unit)")
+	}
+}
+
 func TestSetContainerPassword(t *testing.T) {
 	r := &mockRunner{}
 	err := SetContainerPassword(r, "/rootfs", "alice", "H@rdPa$$w0rd!")

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -55,10 +55,11 @@ sudo nsenter -t <leader_pid> -m -u -i -n -p -- \
     WAYLAND_DISPLAY=... PIPEWIRE_REMOTE=... PULSE_SERVER=... \
     XDG_RUNTIME_DIR=... DBUS_SESSION_BUS_ADDRESS=... \
     [__NV_PRIME_RENDER_OFFLOAD=1 __GLX_VENDOR_LIBRARY_NAME=nvidia] \
+    && /usr/local/bin/intuneme-session-setup \
     && nohup <app> >/dev/null 2>&1 &"
 ```
 
-The script conditionally sets Wayland, PipeWire, PulseAudio, Nvidia, and D-Bus variables based on detected host sockets and GPU.
+The script conditionally sets Wayland, PipeWire, PulseAudio, Nvidia, and D-Bus variables based on detected host sockets and GPU. It then runs `intuneme-session-setup` (see [Session Setup](#session-setup-shared-between-login-and-launch-paths)) before launching the app — because this is a non-login shell, that script is what pushes `DISPLAY`/`XAUTHORITY` into the D-Bus activation environment (so the GTK identity broker can start) and unlocks the keyring. Without it the broker crashes on activation and authentication fails.
 
 A sudoers rule at `/etc/sudoers.d/intuneme-exec` makes this passwordless so the GNOME extension can launch apps without a terminal. See [CLAUDE.md](../CLAUDE.md) for why alternatives (`machinectl shell`, `systemd-run`) don't work.
 
@@ -148,22 +149,28 @@ Container password is set via a bind-mounted temp file to avoid shell injection:
 
 Password validation (both CLI-side and container PAM): minimum 12 chars, at least one digit, uppercase, lowercase, and special character, no username substring.
 
-### Profile Script Environment
+### Session Setup (shared between login and launch paths)
 
-The container profile script (`/etc/profile.d/intuneme.sh`, embedded in Go binary) runs on every login shell session and:
+All session initialization lives in **`/usr/local/bin/intuneme-session-setup`** (embedded in the Go binary as `intuneme-session-setup.sh`, installed by `provision.InstallSessionScripts`). It is invoked from **both** session-entry paths so they behave identically:
 
-1. Reads `DISPLAY` from `/etc/intuneme-host-display` (written by `start`), defaults to `:0`
-2. Extends `PATH` with `/opt/microsoft/intune/bin` and `/opt/microsoft/microsoft-azurevpnclient`
-3. Sets `XAUTHORITY=/run/host-xauthority` if bind-mounted
-4. Imports display/audio vars into systemd user session so services see them
-5. Detects Wayland (`WAYLAND_DISPLAY`), PipeWire (`PIPEWIRE_REMOTE`), PulseAudio (`PULSE_SERVER`) from `/run/host-*` sockets
-6. Sets `__NV_PRIME_RENDER_OFFLOAD=1` and `__GLX_VENDOR_LIBRARY_NAME=nvidia` when `/run/host-nvidia` exists, and imports them into the systemd user session
-7. On first login per boot (marker at `/tmp/.intuneme-keyring-init-done`):
+- **`/etc/profile.d/intuneme.sh`** *sources* it on interactive login (`machinectl shell`), so the exported env lands in the login shell too.
+- **`nspawn.Exec()`** *executes* it before launching a GUI app via nsenter. **This is the critical part:** the nsenter path is a *non-login* shell, so `/etc/profile.d` is never sourced. Before this script existed, the steps below ran only on login — which is why launching Edge from the GNOME extension (nsenter, no login) left the broker without a display and the keyring locked, so **authentication failed**.
+
+The script (safe to source or execute; idempotent) does:
+
+1. Sets `XDG_RUNTIME_DIR` / `DBUS_SESSION_BUS_ADDRESS` if unset, so it works from any caller
+2. Reads `DISPLAY` from `/etc/intuneme-host-display` (written by `start`), defaults to `:0`
+3. Extends `PATH`; sets `XAUTHORITY=/run/host-xauthority` if bind-mounted
+4. Detects Wayland (`WAYLAND_DISPLAY`), PipeWire (`PIPEWIRE_REMOTE`), PulseAudio (`PULSE_SERVER`), Nvidia (`__NV_PRIME_RENDER_OFFLOAD` / `__GLX_VENDOR_LIBRARY_NAME`) from `/run/host-*`
+5. Propagates the env with **both** `systemctl --user import-environment` **and `dbus-update-activation-environment --systemd`**. The latter is essential: the identity broker is a **GTK app that the session D-Bus daemon activates on demand**, and it inherits `DISPLAY`/`XAUTHORITY` only from the D-Bus activation environment. Without it the broker dies on startup with `cannot open display` and Edge cannot authenticate.
+6. On first session per boot (marker at `/tmp/.intuneme-keyring-init-done`), and only if the login collection is locked:
    - Ensures `~/.local/share/keyrings/default` points to `login`
-   - Initializes `gnome-keyring-daemon` with `--replace --unlock --components=secrets,pkcs11`
-   - Stores a test secret via `secret-tool` to force default collection creation (without this, `ReadAlias("default")` returns `/` and the broker can't store credentials)
-   - Restarts both `microsoft-identity-broker.service` (user) and `microsoft-identity-device-broker.service` (system) to pick up the initialized keyring
-8. Starts `intune-agent.timer` for compliance checks if not already active
+   - **Kills all keyring daemons (`pkill -x gnome-keyring-d`) and starts exactly one** via `echo "" | gnome-keyring-daemon --unlock --components=secrets,pkcs11 -d`. The well-known `org.freedesktop.secrets` name is held by whichever daemon claimed it first (often the systemd socket-activated one); a `--replace --unlock` daemon does *not* take that name, so its unlock never reaches the daemon the broker talks to. Note `echo ""` (newline = empty password) — `printf ""` would send EOF = "no password" and create nothing.
+   - Forces default-collection creation via `secret-tool` (without this, `ReadAlias("default")` returns `/` and the broker can't store credentials)
+   - Restarts **only** `microsoft-identity-device-broker.service` (system). The user-session `com.microsoft.identity.broker1` is **D-Bus-activated, not a systemd unit**, so it is not restarted — it re-activates with a fresh process (and now-correct environment) on the next call from Edge. (The previous `systemctl --user restart microsoft-identity-broker.service` always errored with "Unit not found".)
+7. Starts `intune-agent.timer` for compliance checks if not already active
+
+`start` reinstalls the script via `provision.SessionScriptsInstalled` / `InstallSessionScripts` if missing, self-healing containers provisioned before it existed (same pattern as the sudoers rule).
 
 ### State Preservation Across Recreate
 

--- a/yeti/container-lifecycle.md
+++ b/yeti/container-lifecycle.md
@@ -17,7 +17,7 @@ One-time provisioning that creates the container from scratch.
 5. **Configure GPU access** — Detect host render group GID, create matching group in container via `EnsureRenderGroup()` (resolves GID conflicts by reassigning the conflicting group to a free system GID 999–100), add user to it
 6. **Create container user** — Match host UID/GID. Handles three cases: (a) rename existing user with same UID (e.g., `ubuntu` from OCI base) via `usermod --login --move-home`, (b) create new user with `useradd`, (c) update existing user's groups with `usermod --append`
 7. **Set password** — Validate locally (12+ chars, at least one digit/uppercase/lowercase/special char, no username substring), then pass via bind-mounted read-only temp file to `chpasswd` inside the container (avoids shell injection)
-8. **Write fixups** — `<hostname>LXC` to `/etc/hostname`, `/etc/hosts`, `profile.d/intuneme.sh`, `fix-home-ownership.service` (oneshot unit to chown home dir), container-side sudoers at `/etc/sudoers.d/intuneme` (`<user> ALL=(ALL) NOPASSWD: ALL`)
+8. **Write fixups** — `<hostname>LXC` to `/etc/hostname`, `/etc/hosts`, session scripts (`/usr/local/bin/intuneme-session-setup` + `profile.d/intuneme.sh` that sources it, via `provision.InstallSessionScripts`), `fix-home-ownership.service` (oneshot unit to chown home dir), container-side sudoers at `/etc/sudoers.d/intuneme` (`<user> ALL=(ALL) NOPASSWD: ALL`)
 9. **Install polkit rule** — `50-intuneme.rules` to `/etc/polkit-1/rules.d/` (allows sudo group to use machinectl)
 10. **Install sudoers rule** — `/etc/sudoers.d/intuneme-exec` for passwordless nsenter (validated with `visudo -c`)
 11. **SELinux** (if enabled — enforcing or permissive) — Label rootfs as `container_file_t` via `semanage fcontext` + `restorecon`, install `intuneme-machined` policy module granting `systemd_machined_t` PTY access (`user_devpts_t`) and `/tmp` symlink traversal (`user_tmp_t`)
@@ -34,13 +34,14 @@ Boots the container and sets up runtime environment.
 3. **Detect Nvidia GPU** — If `/dev/nvidiactl` exists, detect device nodes, parse `ldconfig -p` for host libraries, prepare bind mounts for lib dirs and ICD files
 4. **Prepare broker proxy** (if enabled) — Create runtime directory, add bind mount
 5. **Validate sudo** — Prompt for password if needed (`nspawn.ValidateSudo()`)
-6. **Write display marker** — Write host `$DISPLAY` to `rootfs/etc/intuneme-host-display` (read by profile.d script on container login)
+6. **Write display marker** — Write host `$DISPLAY` to `rootfs/etc/intuneme-host-display` (read by `intuneme-session-setup` on login and on every app launch)
 7. **Boot container** — `systemd-nspawn` with all bind mounts, DRI device cgroup rules, Nvidia device binds with explicit `DeviceAllow`, `--boot` flag
 8. **Wait for registration** — Poll `machinectl` up to 30 seconds until container is listed
 9. **Clean stale Nvidia symlinks** — Always runs (even on non-Nvidia boots) to remove symlinks from previous sessions
 10. **Setup Nvidia libraries** (if detected) — Create symlinks in container's `/usr/lib/x86_64-linux-gnu/` → `/run/host-nvidia/<index>/`, then run `ldconfig`
 11. **Install udev rules** — YubiKey (`70-intuneme-yubikey.rules`) and video (`70-intuneme-video.rules`) hotplug rules + helper script (`/usr/local/lib/intuneme/usb-hotplug`)
 12. **Ensure sudoers** — Reinstall sudoers rule if missing (handles upgrades from older versions)
+12b. **Ensure session scripts** — Reinstall `/usr/local/bin/intuneme-session-setup` + `profile.d/intuneme.sh` if missing (`provision.SessionScriptsInstalled` / `InstallSessionScripts`); self-heals containers provisioned before the shared script existed
 13. **Reconcile user groups** — `provision.EnsureUserGroups()` reads the container user's groups via `id -nG` (run as root inside the container's mount namespace via nsenter) and runs `usermod -aG <group> <user>` for any missing group in `requiredRuntimeGroups()` (currently just `plugdev`, required for pcscd access per issue #146). Idempotent; warns and continues on failure.
 14. **Forward existing YubiKeys** — Scan sysfs for Yubico vendor ID `1050`, forward USB device nodes + associated hidraw devices
 15. **Forward existing video devices** — Glob `/dev/video*` and `/dev/media*`, forward each with `0660 root:video` permissions
@@ -128,11 +129,11 @@ Supports `--json` for machine-readable output via `clix.OutputJSON()`.
 
 Opens an interactive bash login shell inside the container.
 
-Uses `machinectl shell <user>@<machine> /bin/bash --login`. The login shell sources `/etc/profile.d/intuneme.sh` which sets up DISPLAY, audio, and keyring.
+Uses `machinectl shell <user>@<machine> /bin/bash --login`. The login shell sources `/etc/profile.d/intuneme.sh`, which in turn sources the shared `/usr/local/bin/intuneme-session-setup` to set up DISPLAY, audio, the D-Bus activation environment, and the keyring.
 
 ## `intuneme open edge` / `intuneme open portal`
 
-Launches GUI apps via `nspawn.Exec()`. Uses the nsenter pattern described in [OVERVIEW.md](OVERVIEW.md#command-execution-inside-the-container). Both are built from a shared `makeOpenAppCmd()` factory.
+Launches GUI apps via `nspawn.Exec()`. Uses the nsenter pattern described in [OVERVIEW.md](OVERVIEW.md#command-execution-inside-the-container). Both are built from a shared `makeOpenAppCmd()` factory. Because the nsenter path is a *non-login* shell, `nspawn.Exec()` runs `/usr/local/bin/intuneme-session-setup` before launching the app — this is what gives the D-Bus-activated identity broker a DISPLAY and an unlocked keyring, without which authentication fails.
 
 ## `intuneme udev install` / `intuneme udev remove`
 


### PR DESCRIPTION
## Problem

Edge in a running container couldn't authenticate. Root cause traced by systematic debugging:

The Microsoft identity broker (`com.microsoft.identity.broker1`) is a **GTK app** that the session D-Bus daemon activates on demand. It inherits `DISPLAY`/`XAUTHORITY` only from the **D-Bus activation environment**. Those vars — and the gnome-keyring unlock — were set only by `/etc/profile.d/intuneme.sh`, which runs **only on login shells**.

The GNOME extension launches apps via `nspawn.Exec()` (`nsenter` + `su -c`), a **non-login** shell that never sources `/etc/profile.d`. So the broker activated with no display, died instantly (`Gtk-WARNING cannot open display: :0`, exit 1 → caller sees *"Message recipient disconnected from message bus without replying"*), and Edge SSO failed. Edge itself runs fine because `Exec` sets `DISPLAY` in *its own* env — but the D-Bus-activated broker inherits none of that.

Confirmed by running the broker binary with vs. without `DISPLAY` (crash vs. survives), and by `getLinuxBrokerVersion` returning `{"linuxBrokerVersion":"3.0.2"}` once the activation env carried a display.

## Fix

Extract all session init into a shared **`/usr/local/bin/intuneme-session-setup`**, invoked by both entry paths so they behave identically:
- `/etc/profile.d/intuneme.sh` **sources** it (login path).
- `nspawn.Exec()` **executes** it before launching the app (nsenter path).

It now also pushes env into the D-Bus activation environment via `dbus-update-activation-environment --systemd` (the actual broker-display fix).

### Latent bugs fixed while tracing this
- **Keyring unlock never reached the right daemon.** The old `gnome-keyring-daemon --replace --unlock` spawns a daemon that does *not* take the well-known `org.freedesktop.secrets` name from the systemd-managed daemon, so its unlock was invisible to the broker. Replaced with a reliable single-daemon unlock (`pkill -x gnome-keyring-d`, then `echo "" | gnome-keyring-daemon --unlock`; note `echo ""` = newline/empty-password, not `printf ""` = EOF/no-password). Guarded to act only when actually locked.
- **`systemctl --user restart microsoft-identity-broker.service` always errored** — the user broker is D-Bus-activated, not a systemd unit. Removed; it re-activates on the next call. The system device broker is still restarted.

`start` reinstalls the script if missing (mirrors the existing sudoers self-heal), so existing containers are fixed on next start.

## Testing
- `make fmt`, `make lint` (0 issues), `go test ./...` (all pass), `shellcheck` clean on both scripts.
- New tests: `TestInstallSessionScripts`, `TestSessionScriptsInstalled`, `TestSessionSetupScriptContent` (guards the activation-env push, empty-password unlock, and that the broken broker restart isn't reintroduced).
- Verified live: after applying the equivalent steps to a running container, the broker replies to `getLinuxBrokerVersion`/`getAccounts` and **Edge authenticates**.

## Docs
Updated `CLAUDE.md`, `yeti/OVERVIEW.md`, and `yeti/container-lifecycle.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)