### PR TITLE
Fix DRI cgroup permissions for auth browser

### DIFF
--- a/internal/nspawn/nspawn.go
+++ b/internal/nspawn/nspawn.go
@@ -121,9 +121,9 @@ func DetectHostSockets(uid int) []BindMount {
 	return mounts
 }
 
-// DetectDRIDevices scans for DRM card and render devices.
-// Returns individual device bind mounts instead of a directory bind so that
-// nspawn correctly adds each device to the cgroup DeviceAllow list.
+// DetectDRIDevices scans for DRM card and render devices. Returns individual
+// device bind mounts instead of a directory bind so nspawn can grant each node
+// in the cgroup DeviceAllow list.
 func DetectDRIDevices() []BindMount {
 	var mounts []BindMount
 	for _, pattern := range []string{"/dev/dri/card*", "/dev/dri/renderD*"} {
@@ -136,19 +136,25 @@ func DetectDRIDevices() []BindMount {
 }
 
 // BuildBootArgs returns the systemd-nspawn arguments to boot the container.
-// nvidiaDevices are Nvidia device nodes that need explicit DeviceAllow entries
-// (unlike DRI devices, nspawn does not auto-allow /dev/nvidia* in cgroups).
+// DRI devices are detected internally; nvidiaDevices are detected by the caller
+// because Nvidia also needs host library and ICD setup.
 func BuildBootArgs(rootfs, machine, intuneHome, containerHome string, sockets []BindMount, nvidiaDevices []BindMount) []string {
+	return buildBootArgs(rootfs, machine, intuneHome, containerHome, sockets, DetectDRIDevices(), nvidiaDevices)
+}
+
+func buildBootArgs(rootfs, machine, intuneHome, containerHome string, sockets, driDevices, nvidiaDevices []BindMount) []string {
 	args := []string{
 		"-D", rootfs,
 		fmt.Sprintf("--machine=%s", machine),
 		fmt.Sprintf("--bind=%s:%s", intuneHome, containerHome),
 		"--bind=/tmp/.X11-unix",
 	}
-	// Bind DRI devices individually so nspawn adds them to the cgroup allow list.
-	// A directory bind (--bind=/dev/dri) does not register contained devices.
-	for _, dri := range DetectDRIDevices() {
+	// Bind DRI devices individually and grant rwm in the cgroup. systemd-nspawn's
+	// automatic device policy grants only rw for these nodes, but WebKitGTK's
+	// auth browser needs DRM ioctls that create GBM/KMS buffers.
+	for _, dri := range driDevices {
 		args = append(args, fmt.Sprintf("--bind=%s", dri.Host))
+		args = append(args, fmt.Sprintf("--property=DeviceAllow=%s rwm", dri.Host))
 	}
 	// Bind Nvidia device nodes with explicit cgroup DeviceAllow.
 	for _, dev := range nvidiaDevices {

--- a/internal/nspawn/nspawn_test.go
+++ b/internal/nspawn/nspawn_test.go
@@ -68,19 +68,29 @@ func TestBuildBootArgs(t *testing.T) {
 	if !strings.Contains(joined, "--bind=/tmp/.X11-unix") {
 		t.Errorf("missing X11 bind in: %s", joined)
 	}
-	// DRI devices are bound individually (not as a directory) so that nspawn
-	// adds them to the cgroup allow list. The exact devices depend on the
-	// host, so just verify at least one DRI bind is present if the host has DRI.
-	if _, err := os.Stat("/dev/dri/renderD128"); err == nil {
-		if !strings.Contains(joined, "--bind=/dev/dri/renderD128") {
-			t.Errorf("missing DRI renderD128 bind in: %s", joined)
-		}
-	}
 	if !strings.Contains(joined, "--bind=/run/user/1000/wayland-0:/run/host-wayland") {
 		t.Errorf("missing wayland socket bind in: %s", joined)
 	}
 	if !strings.Contains(joined, "-b") {
 		t.Errorf("missing -b (boot) flag in: %s", joined)
+	}
+}
+
+func TestBuildBootArgs_DRIDevices(t *testing.T) {
+	driDevices := []BindMount{
+		{Host: "/dev/dri/card0", Container: "/dev/dri/card0"},
+		{Host: "/dev/dri/renderD128", Container: "/dev/dri/renderD128"},
+	}
+	args := buildBootArgs("/tmp/rootfs", "intuneme", "/home/testuser/Intune", "/home/testuser", nil, driDevices, nil)
+
+	joined := strings.Join(args, " ")
+	for _, dev := range driDevices {
+		if !strings.Contains(joined, "--bind="+dev.Host) {
+			t.Errorf("missing DRI bind for %s in: %s", dev.Host, joined)
+		}
+		if !strings.Contains(joined, "--property=DeviceAllow="+dev.Host+" rwm") {
+			t.Errorf("missing DRI DeviceAllow rwm for %s in: %s", dev.Host, joined)
+		}
 	}
 }
 
@@ -266,11 +276,11 @@ func TestBuildBootArgs_ReadOnlyBinds(t *testing.T) {
 }
 
 func TestBuildBootArgs_NoNvidiaDevices(t *testing.T) {
-	args := BuildBootArgs("/tmp/rootfs", "intuneme", "/home/testuser/Intune", "/home/testuser", nil, nil)
+	args := buildBootArgs("/tmp/rootfs", "intuneme", "/home/testuser/Intune", "/home/testuser", nil, nil, nil)
 
 	joined := strings.Join(args, " ")
-	if strings.Contains(joined, "DeviceAllow") {
-		t.Errorf("unexpected DeviceAllow in args with no Nvidia devices: %s", joined)
+	if strings.Contains(joined, "DeviceAllow=/dev/nvidia") {
+		t.Errorf("unexpected Nvidia DeviceAllow in args with no Nvidia devices: %s", joined)
 	}
 	if strings.Contains(joined, "nvidia") {
 		t.Errorf("unexpected nvidia reference in args with no Nvidia devices: %s", joined)

--- a/site/user-guide/nvidia-gpu.md
+++ b/site/user-guide/nvidia-gpu.md
@@ -19,7 +19,7 @@ On every `intuneme start`, stale symlinks from a previous Nvidia session are cle
 
 ## Non-Nvidia systems
 
-Systems without Nvidia GPUs are unaffected. The detection check is a simple file existence test (`/dev/nvidiactl`), and all Nvidia-specific steps are skipped when no GPU is found. Standard DRI devices (`/dev/dri/card*`, `/dev/dri/renderD*`) are always forwarded regardless.
+Systems without Nvidia GPUs are unaffected. The detection check is a simple file existence test (`/dev/nvidiactl`), and all Nvidia-specific steps are skipped when no GPU is found. Standard DRI devices (`/dev/dri/card*`, `/dev/dri/renderD*`) are always forwarded regardless, with explicit `rwm` cgroup access so embedded WebKitGTK authentication windows can create GPU buffers.
 
 ## Requirements
 

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -73,7 +73,7 @@ A sudoers rule at `/etc/sudoers.d/intuneme-exec` makes this passwordless so the 
 | PipeWire | `$XDG_RUNTIME_DIR/pipewire-0` | `/run/host-pipewire` | Auto-detected on start |
 | PulseAudio | `$XDG_RUNTIME_DIR/pulse/native` | `/run/host-pulse` | Auto-detected on start |
 | X11 auth | `$XAUTHORITY` (see search order below) | `/run/host-xauthority` | Auto-detected on start |
-| GPU (DRI) | `/dev/dri/card*`, `/dev/dri/renderD*` | Same | Individual devices for cgroup |
+| GPU (DRI) | `/dev/dri/card*`, `/dev/dri/renderD*` | Same | Individual devices with explicit `DeviceAllow=<dev> rwm` |
 | GPU (Nvidia) | `/dev/nvidia*` | Same | When Nvidia detected; explicit `DeviceAllow` |
 | Nvidia libs | Host lib dirs (from `ldconfig`) | `/run/host-nvidia/<index>/` | Read-only; when Nvidia detected |
 | Nvidia ICD | `/usr/share/vulkan/icd.d/nvidia_icd.json` etc. | Same | Read-only; when Nvidia detected |
@@ -105,7 +105,7 @@ YubiKeys and video capture devices (webcams) can be forwarded into the running c
 On hosts with Nvidia GPUs, the container needs the device nodes and host userspace libraries (which must match the kernel module version exactly). This is handled by `internal/nvidia/` using a detect-at-start, bind-mount, symlink approach (similar to distrobox):
 
 1. **Detection** — `nvidia.IsPresent()` checks for `/dev/nvidiactl`
-2. **Device bind mounts** — `DetectDevices()` globs `/dev/nvidia*` and `/dev/nvidia-caps/*`. Unlike DRI devices, nspawn does not auto-allow Nvidia devices in cgroups, so each gets an explicit `--property=DeviceAllow=<dev> rwm` boot arg
+2. **Device bind mounts** — `DetectDevices()` globs `/dev/nvidia*` and `/dev/nvidia-caps/*`. Each gets an explicit `--property=DeviceAllow=<dev> rwm` boot arg. DRI devices use the same explicit `rwm` pattern because nspawn's automatic DRI allowlist may grant only `rw`, which is insufficient for WebKitGTK auth-browser GBM/KMS buffer creation.
 3. **Library discovery** — `HostLibraries()` parses `ldconfig -p` output for Nvidia libraries (x86-64 only), deduplicating by basename
 4. **Library bind mounts** — `LibDirMounts()` maps unique host library directories to `/run/host-nvidia/0/`, `/run/host-nvidia/1/`, etc. (read-only). The indexed paths avoid basename collisions
 5. **ICD files** — `HostICDFiles()` and `ICDMounts()` bind-mount Vulkan/EGL vendor JSON files at their standard paths

--- a/yeti/container-lifecycle.md
+++ b/yeti/container-lifecycle.md
@@ -35,7 +35,7 @@ Boots the container and sets up runtime environment.
 4. **Prepare broker proxy** (if enabled) — Create runtime directory, add bind mount
 5. **Validate sudo** — Prompt for password if needed (`nspawn.ValidateSudo()`)
 6. **Write display marker** — Write host `$DISPLAY` to `rootfs/etc/intuneme-host-display` (read by `intuneme-session-setup` on login and on every app launch)
-7. **Boot container** — `systemd-nspawn` with all bind mounts, DRI device cgroup rules, Nvidia device binds with explicit `DeviceAllow`, `--boot` flag
+7. **Boot container** — `systemd-nspawn` with all bind mounts, DRI device binds plus explicit `DeviceAllow=<dev> rwm` rules, Nvidia device binds with explicit `DeviceAllow`, `--boot` flag
 8. **Wait for registration** — Poll `machinectl` up to 30 seconds until container is listed
 9. **Clean stale Nvidia symlinks** — Always runs (even on non-Nvidia boots) to remove symlinks from previous sessions
 10. **Setup Nvidia libraries** (if detected) — Create symlinks in container's `/usr/lib/x86_64-linux-gnu/` → `/run/host-nvidia/<index>/`, then run `ldconfig`


### PR DESCRIPTION
The Intune Portal reauth flow can hang when the Microsoft identity broker's WebKitGTK auth window tries to create GBM/KMS buffers through `/dev/dri`. This started showing up after DRI forwarding moved from a directory bind to individual device binds: nspawn's automatic device policy exposed the nodes as `rw`, but the auth browser needs `rwm`.

### Approach

- Add explicit `DeviceAllow=<dev> rwm` entries for detected `/dev/dri/card*` and `/dev/dri/renderD*` nodes during container boot.
- Keep Nvidia handling separate, but document that DRI now follows the same explicit cgroup access pattern.
- Add deterministic coverage for DRI `rwm` boot args instead of relying on the host test machine having a specific `/dev/dri/renderD128` node.

### Validation

- `make fmt`
- `go test ./internal/nspawn`
- `make test`
- `make lint`
