### PR TITLE
Added intuneme mcp functionality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,16 @@ A sudoers rule at `/etc/sudoers.d/intuneme-exec` (installed by `intuneme init`, 
 
 **Session setup runs on the nsenter path too.** The nsenter shell is *non-login*, so it never sources `/etc/profile.d`. `nspawn.Exec()` therefore runs `/usr/local/bin/intuneme-session-setup` (the shared script that `/etc/profile.d/intuneme.sh` also sources) before launching the app. That script pushes `DISPLAY`/`XAUTHORITY` into the **D-Bus activation environment** (`dbus-update-activation-environment`) and unlocks gnome-keyring. This is mandatory: the Microsoft identity broker is a GTK app that the session D-Bus daemon activates on demand — without a display in the activation environment it dies on startup (`cannot open display`) and **Edge can't authenticate**. `start` reinstalls the script if missing. See `yeti/OVERVIEW.md` → "Session Setup".
 
+## Running MCP servers in the container (`intuneme mcp`)
+
+`intuneme mcp` runs a host-provided MCP server binary *inside* the container with its stdio wired to a host client (e.g. VS Code). Use it when a server must authenticate against the container's enrolled tenant and the broker proxy can't help — most notably a two-tenant setup (one tenant on the host, a second inside intuneme), since a D-Bus well-known name has one owner per bus and can't represent two brokers.
+
+Key design points:
+
+- **Foreground exec, no TTY.** It uses `nspawn.ExecForeground()` (not `Exec()`): same `nsenter` shape and sudoers rule, but `exec` with attached stdio instead of `nohup … &`. Backgrounding or allocating a TTY corrupts JSON-RPC framing.
+- **Binary stays out of the rootfs.** The server binary lives on the host (`mcp_binary` config key or `--binary`). Its directory is bind-mounted read-only at `/opt/intuneme-mcp` via `machinectl bind` (authorized passwordless by the polkit `manage-machines` rule). The bind is runtime-only and re-established on demand, so it **survives `intuneme recreate`** — nothing is added to `ubuntu-intune/`.
+- **Server-agnostic.** No assumption about a particular tool; any self-contained MCP server works. The server's own arguments come from the `mcp_args` config key (e.g. `["mcp"]` for `workiq mcp`), with trailing `intuneme mcp -- args...` overriding them — this keeps the VS Code config to just `["mcp"]`. A `DOTNET_BUNDLE_EXTRACT_BASE_DIR` env var is set (harmless for non-.NET) so single-file .NET servers extract to ephemeral `/tmp` and the mount can stay read-only.
+
 ## Before committing
 
 Always run `make fmt` and `make lint` before committing. Fix any lint errors before creating commits.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 - Container lifecycle management (`init`, `start`, `stop`, `destroy`, `recreate`)
 - Broker proxy for host-side single sign-on (Edge, VS Code, and other MSAL apps)
+- Run MCP servers inside the container, wired to host stdio (`mcp`) — for tools that must authenticate against the container's tenant
 - Device hotplug — YubiKey and webcam passthrough via udev rules
 - GNOME Quick Settings extension for start/stop and app launch without a terminal
 - Desktop shortcuts for Microsoft Edge and Intune Portal

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -1,0 +1,137 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/frostyard/intuneme/internal/config"
+	"github.com/frostyard/intuneme/internal/nspawn"
+	"github.com/frostyard/intuneme/internal/runner"
+	"github.com/spf13/cobra"
+)
+
+// dotnetExtractDir is where a self-contained single-file .NET binary unpacks its
+// native libraries inside the container. Kept on the container's ephemeral /tmp so
+// the bind-mounted binary directory can stay read-only.
+const dotnetExtractDir = "/tmp/intuneme-mcp-extract"
+
+var mcpBinaryFlag string
+
+// runMCP launches an MCP server binary in the foreground inside the container so
+// its stdio is wired straight to the caller (VS Code). The host binary directory
+// is bind-mounted at runtime, so the binary lives outside the rootfs and the setup
+// survives `intuneme recreate` — the bind is re-established on demand.
+func runMCP(r runner.Runner, root, binaryPath string, serverArgs []string) error {
+	cfg, err := config.Load(root)
+	if err != nil {
+		return err
+	}
+
+	if _, err := os.Stat(cfg.RootfsPath); err != nil {
+		return fmt.Errorf("not initialized — run 'intuneme init' first")
+	}
+
+	if !nspawn.IsRunning(r, cfg.MachineName) {
+		return fmt.Errorf("container is not running — run 'intuneme start' first")
+	}
+
+	if binaryPath == "" {
+		binaryPath = cfg.MCPBinary
+	}
+	if binaryPath == "" {
+		return fmt.Errorf("no MCP server binary configured — pass --binary <path> " +
+			"or set mcp_binary in config.toml")
+	}
+	binaryPath, err = filepath.Abs(binaryPath)
+	if err != nil {
+		return fmt.Errorf("resolve binary path: %w", err)
+	}
+	if info, err := os.Stat(binaryPath); err != nil {
+		return fmt.Errorf("MCP binary not found at %s — place a self-contained "+
+			"binary there or pass --binary (or set mcp_binary in config.toml): %w",
+			binaryPath, err)
+	} else if info.IsDir() {
+		return fmt.Errorf("MCP binary path %s is a directory, expected a file", binaryPath)
+	}
+
+	hostDir := filepath.Dir(binaryPath)
+	containerBin := nspawn.MCPMountDir + "/" + filepath.Base(binaryPath)
+
+	// Re-establish the runtime bind mount if the binary isn't visible inside the
+	// container (e.g. after a fresh start or recreate). Idempotent and passwordless.
+	if err := nspawn.EnsureBind(r, cfg.MachineName, cfg.HostUser,
+		hostDir, nspawn.MCPMountDir, containerBin); err != nil {
+		return err
+	}
+
+	// Trailing `-- args...` override the configured default args.
+	if len(serverArgs) == 0 {
+		serverArgs = cfg.MCPArgs
+	}
+
+	// Build: env DOTNET_BUNDLE_EXTRACT_BASE_DIR=<tmp> <binary> <args...>
+	// The DOTNET_* var only affects self-contained single-file .NET binaries and is
+	// harmless otherwise; it keeps their native-library extraction on ephemeral /tmp
+	// so the bind-mounted binary directory can stay read-only.
+	parts := []string{
+		"env",
+		"DOTNET_BUNDLE_EXTRACT_BASE_DIR=" + dotnetExtractDir,
+		nspawn.ShellQuote(containerBin),
+	}
+	for _, a := range serverArgs {
+		parts = append(parts, nspawn.ShellQuote(a))
+	}
+	command := strings.Join(parts, " ")
+
+	return nspawn.ExecForeground(r, cfg.MachineName, cfg.HostUser, cfg.HostUID, command)
+}
+
+var mcpCmd = &cobra.Command{
+	Use:   "mcp [-- args...]",
+	Short: "Run an MCP server inside the container, wired to stdio",
+	Long: `Run a self-contained MCP server binary inside the container in the
+foreground, with its stdin/stdout/stderr attached to the caller. This lets a
+host-side client (e.g. VS Code) speak to an MCP server that must authenticate
+against the container's enrolled tenant — without enabling the broker proxy.
+
+The binary lives on the host (set its path with --binary or the mcp_binary config
+key). Its directory is bind-mounted into the container at runtime, so it stays out
+of the rootfs and survives 'intuneme recreate'. Any MCP server works — there is no
+assumption about a particular tool.
+
+Arguments for the server binary come from the mcp_args config key by default, and
+trailing 'intuneme mcp -- args...' override them. For a server whose stdio mode is
+a subcommand, set e.g. mcp_args = ["mcp"] in config.toml so the VS Code config
+stays minimal:
+
+  {
+    "servers": {
+      "my-server": { "type": "stdio", "command": "intuneme", "args": ["mcp"] }
+    }
+  }
+
+Here "my-server" is just the display name in VS Code; the server's own arguments
+live in mcp_args.`,
+	SilenceUsage:  true,
+	SilenceErrors: false,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		r := &runner.SystemRunner{}
+		root := rootDir
+		if root == "" {
+			var err error
+			root, err = config.DefaultRoot()
+			if err != nil {
+				return err
+			}
+		}
+		return runMCP(r, root, mcpBinaryFlag, args)
+	},
+}
+
+func init() {
+	mcpCmd.Flags().StringVar(&mcpBinaryFlag, "binary", "",
+		"path to the MCP server binary on the host (overrides mcp_binary config)")
+	rootCmd.AddCommand(mcpCmd)
+}

--- a/cmd/mcp_test.go
+++ b/cmd/mcp_test.go
@@ -1,0 +1,259 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/frostyard/intuneme/internal/nspawn"
+)
+
+type mcpMockRunner struct {
+	runCalls      [][]string
+	attachedCalls [][]string
+	probeErr      error // returned for the EnsureBind nsenter "test -e" probe
+	bindErr       error
+	notRunning    bool
+}
+
+func argsContain(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *mcpMockRunner) Run(name string, args ...string) ([]byte, error) {
+	m.runCalls = append(m.runCalls, append([]string{name}, args...))
+	switch {
+	case name == "machinectl" && len(args) > 0 && args[0] == "show":
+		if argsContain(args, "Leader") {
+			return []byte("12345\n"), nil
+		}
+		if m.notRunning {
+			return nil, fmt.Errorf("machine not found")
+		}
+		return []byte("Name=intuneme\n"), nil
+	case name == "sudo" && len(args) > 0 && args[0] == "nsenter":
+		// EnsureBind probe (test -e <bin>).
+		return nil, m.probeErr
+	case name == "machinectl" && len(args) > 0 && args[0] == "bind":
+		return nil, m.bindErr
+	}
+	return nil, nil
+}
+
+func (m *mcpMockRunner) RunAttached(name string, args ...string) error {
+	m.attachedCalls = append(m.attachedCalls, append([]string{name}, args...))
+	return nil
+}
+func (m *mcpMockRunner) RunBackground(string, ...string) error { return nil }
+func (m *mcpMockRunner) LookPath(name string) (string, error) {
+	return "/usr/bin/" + name, nil
+}
+
+func (m *mcpMockRunner) bound() bool {
+	for _, c := range m.runCalls {
+		if len(c) > 1 && c[0] == "machinectl" && c[1] == "bind" {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *mcpMockRunner) lastForegroundCommand(t *testing.T) string {
+	t.Helper()
+	if len(m.attachedCalls) == 0 {
+		t.Fatal("expected a foreground (RunAttached) launch, got none")
+	}
+	// The script is the final argument to su -c.
+	last := m.attachedCalls[len(m.attachedCalls)-1]
+	return last[len(last)-1]
+}
+
+// initializedRoot returns a temp root that looks initialized (rootfs dir exists).
+// When skipBinary is false it also creates a server binary and points the
+// mcp_binary config key at it, returning that path.
+func initializedRoot(t *testing.T, skipBinary bool) (root, binary string) {
+	t.Helper()
+	root = t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "rootfs"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Pin HostUser so the test doesn't depend on $USER.
+	cfg := "host_user = \"tester\"\nhost_uid = 1000\n"
+	if !skipBinary {
+		mcpDir := filepath.Join(root, "mcp")
+		if err := os.MkdirAll(mcpDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		binary = filepath.Join(mcpDir, "server")
+		if err := os.WriteFile(binary, []byte("#!/bin/sh\n"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		cfg += fmt.Sprintf("mcp_binary = %q\n", binary)
+	}
+	if err := os.WriteFile(filepath.Join(root, "config.toml"), []byte(cfg), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return root, binary
+}
+
+func TestRunMCP_NotInitialized(t *testing.T) {
+	r := &mcpMockRunner{}
+	err := runMCP(r, t.TempDir(), "", nil)
+	if err == nil || !strings.Contains(err.Error(), "not initialized") {
+		t.Fatalf("expected 'not initialized' error, got %v", err)
+	}
+}
+
+func TestRunMCP_NotRunning(t *testing.T) {
+	r := &mcpMockRunner{notRunning: true}
+	root, _ := initializedRoot(t, false)
+	err := runMCP(r, root, "", nil)
+	if err == nil || !strings.Contains(err.Error(), "not running") {
+		t.Fatalf("expected 'not running' error, got %v", err)
+	}
+}
+
+func TestRunMCP_NoBinaryConfigured(t *testing.T) {
+	r := &mcpMockRunner{}
+	root, _ := initializedRoot(t, true)
+	err := runMCP(r, root, "", nil)
+	if err == nil || !strings.Contains(err.Error(), "no MCP server binary configured") {
+		t.Fatalf("expected 'no MCP server binary configured' error, got %v", err)
+	}
+}
+
+func TestRunMCP_BinaryNotFound(t *testing.T) {
+	r := &mcpMockRunner{}
+	root, _ := initializedRoot(t, true)
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	err := runMCP(r, root, missing, nil)
+	if err == nil || !strings.Contains(err.Error(), "MCP binary not found") {
+		t.Fatalf("expected 'MCP binary not found' error, got %v", err)
+	}
+}
+
+func TestRunMCP_BindsAndLaunches(t *testing.T) {
+	// probeErr set => binary not yet visible => bind must happen.
+	r := &mcpMockRunner{probeErr: fmt.Errorf("not found")}
+	root, _ := initializedRoot(t, false)
+	if err := runMCP(r, root, "", nil); err != nil {
+		t.Fatalf("runMCP returned error: %v", err)
+	}
+	if !r.bound() {
+		t.Error("expected a 'machinectl bind' call when binary not yet visible")
+	}
+	cmd := r.lastForegroundCommand(t)
+	if !strings.Contains(cmd, "exec env DOTNET_BUNDLE_EXTRACT_BASE_DIR=") {
+		t.Errorf("foreground command missing dotnet extract env: %q", cmd)
+	}
+	if !strings.Contains(cmd, nspawn.MCPMountDir+"/server") {
+		t.Errorf("foreground command missing container binary path: %q", cmd)
+	}
+}
+
+func TestRunMCP_SkipsBindWhenPresent(t *testing.T) {
+	// probeErr nil => already bound => no bind call, still launches.
+	r := &mcpMockRunner{probeErr: nil}
+	root, _ := initializedRoot(t, false)
+	if err := runMCP(r, root, "", nil); err != nil {
+		t.Fatalf("runMCP returned error: %v", err)
+	}
+	if r.bound() {
+		t.Error("did not expect 'machinectl bind' when binary already visible")
+	}
+	if len(r.attachedCalls) == 0 {
+		t.Error("expected a foreground launch")
+	}
+}
+
+func TestRunMCP_PassesArgsVerbatim(t *testing.T) {
+	r := &mcpMockRunner{probeErr: nil}
+	root, _ := initializedRoot(t, false)
+	if err := runMCP(r, root, "", []string{"foo", "bar"}); err != nil {
+		t.Fatalf("runMCP returned error: %v", err)
+	}
+	cmd := r.lastForegroundCommand(t)
+	if !strings.Contains(cmd, "'foo' 'bar'") {
+		t.Errorf("expected args in command, got: %q", cmd)
+	}
+}
+
+func TestRunMCP_UsesConfigArgsByDefault(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "rootfs"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	mcpDir := filepath.Join(root, "mcp")
+	if err := os.MkdirAll(mcpDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	binary := filepath.Join(mcpDir, "server")
+	if err := os.WriteFile(binary, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := fmt.Sprintf("host_user = \"tester\"\nhost_uid = 1000\nmcp_binary = %q\nmcp_args = [\"mcp\"]\n", binary)
+	if err := os.WriteFile(filepath.Join(root, "config.toml"), []byte(cfg), 0644); err != nil {
+		t.Fatal(err)
+	}
+	r := &mcpMockRunner{probeErr: nil}
+	if err := runMCP(r, root, "", nil); err != nil {
+		t.Fatalf("runMCP returned error: %v", err)
+	}
+	cmd := r.lastForegroundCommand(t)
+	if !strings.HasSuffix(strings.TrimSpace(cmd), "'mcp'") {
+		t.Errorf("expected configured mcp_args appended, got: %q", cmd)
+	}
+}
+
+func TestRunMCP_TrailingArgsOverrideConfigArgs(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "rootfs"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	mcpDir := filepath.Join(root, "mcp")
+	if err := os.MkdirAll(mcpDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	binary := filepath.Join(mcpDir, "server")
+	if err := os.WriteFile(binary, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := fmt.Sprintf("host_user = \"tester\"\nhost_uid = 1000\nmcp_binary = %q\nmcp_args = [\"mcp\"]\n", binary)
+	if err := os.WriteFile(filepath.Join(root, "config.toml"), []byte(cfg), 0644); err != nil {
+		t.Fatal(err)
+	}
+	r := &mcpMockRunner{probeErr: nil}
+	if err := runMCP(r, root, "", []string{"serve"}); err != nil {
+		t.Fatalf("runMCP returned error: %v", err)
+	}
+	cmd := r.lastForegroundCommand(t)
+	if strings.Contains(cmd, "'mcp'") {
+		t.Errorf("did not expect configured mcp_args when overridden: %q", cmd)
+	}
+	if !strings.Contains(cmd, "'serve'") {
+		t.Errorf("expected overriding arg, got: %q", cmd)
+	}
+}
+
+func TestRunMCP_CustomBinaryFlagOverridesConfig(t *testing.T) {
+	root, _ := initializedRoot(t, false) // config points at <root>/mcp/server
+	custom := filepath.Join(t.TempDir(), "myserver")
+	if err := os.WriteFile(custom, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	r := &mcpMockRunner{probeErr: fmt.Errorf("not found")}
+	if err := runMCP(r, root, custom, nil); err != nil {
+		t.Fatalf("runMCP returned error: %v", err)
+	}
+	cmd := r.lastForegroundCommand(t)
+	if !strings.Contains(cmd, nspawn.MCPMountDir+"/myserver") {
+		t.Errorf("expected custom binary basename in command, got: %q", cmd)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,17 @@ type Config struct {
 	HostUser    string `toml:"host_user"`
 	BrokerProxy bool   `toml:"broker_proxy"`
 	Insiders    bool   `toml:"insiders"`
+	// MCPBinary is the host path to a self-contained MCP server binary that
+	// `intuneme mcp` runs inside the container. Empty means none is configured
+	// (must be supplied via --binary). The directory holding it is bind-mounted
+	// into the container at runtime, so it lives outside the rootfs and survives
+	// recreate.
+	MCPBinary string `toml:"mcp_binary"`
+	// MCPArgs are the default arguments passed to the MCP server binary when
+	// `intuneme mcp` is invoked without trailing `-- args...`. For example
+	// ["mcp"] makes `intuneme mcp` run `<binary> mcp`. Keeps the VS Code config
+	// minimal (just ["mcp"]) by moving the server's own subcommand here.
+	MCPArgs []string `toml:"mcp_args"`
 }
 
 func DefaultRoot() (string, error) {

--- a/internal/nspawn/nspawn.go
+++ b/internal/nspawn/nspawn.go
@@ -205,9 +205,70 @@ func Exec(r runner.Runner, machine, user string, uid int, command string) error 
 	if err != nil {
 		return err
 	}
+	script := buildSessionEnvScript(uid) +
+		fmt.Sprintf("\nnohup %s >/dev/null 2>&1 &", command)
+	if _, err := r.Run("sudo", buildNsenterArgs(leaderPID, user, script)...); err != nil {
+		return fmt.Errorf("exec in container failed: %w", err)
+	}
+	return nil
+}
+
+// ExecForeground runs a command inside the container in the FOREGROUND with the
+// caller's stdin/stdout/stderr attached. Unlike Exec it does not background the
+// process — this is required for stdio-transport servers (e.g. MCP) where the
+// parent must speak JSON-RPC over the child's stdin/stdout. No TTY is allocated
+// (nsenter here is non-allocating), which keeps the JSON-RPC framing intact.
+// Reuses the same nsenter shape as Exec, so the intuneme-exec sudoers rule
+// authorizes it passwordless.
+func ExecForeground(r runner.Runner, machine, user string, uid int, command string) error {
+	leaderPID, err := LeaderPID(r, machine)
+	if err != nil {
+		return err
+	}
+	script := buildSessionEnvScript(uid) + fmt.Sprintf("\nexec %s", command)
+	if err := r.RunAttached("sudo", buildNsenterArgs(leaderPID, user, script)...); err != nil {
+		return fmt.Errorf("foreground exec in container failed: %w", err)
+	}
+	return nil
+}
+
+// MCPMountDir is the fixed container path where the host directory holding an
+// MCP server binary is bind-mounted by EnsureBind. The mount is runtime-only
+// (gone on poweroff) so the binary never enters the rootfs and survives
+// `intuneme recreate`.
+const MCPMountDir = "/opt/intuneme-mcp"
+
+// EnsureBind makes hostDir available read-only at containerDir inside the running
+// machine, idempotently. It first probes whether probePath already exists inside
+// the container (via nsenter in its mount namespace) and only calls
+// `machinectl bind` if it does not. `machinectl bind` is authorized passwordless
+// by the intuneme polkit rule (org.freedesktop.machine1.manage-machines), so this
+// re-establishes the mount automatically after a recreate without a prompt.
+func EnsureBind(r runner.Runner, machine, user, hostDir, containerDir, probePath string) error {
+	leaderPID, err := LeaderPID(r, machine)
+	if err != nil {
+		return err
+	}
+	probe := buildNsenterArgs(leaderPID, user, "test -e "+ShellQuote(probePath))
+	if _, err := r.Run("sudo", probe...); err == nil {
+		return nil // already bound and visible
+	}
+	if out, err := r.Run("machinectl", "bind", "--read-only", "--mkdir",
+		machine, hostDir, containerDir); err != nil {
+		return fmt.Errorf("bind %s into container %s: %w\n%s", hostDir, machine, err, out)
+	}
+	return nil
+}
+
+// buildSessionEnvScript returns the shell prologue that initializes a container
+// session the same way an interactive login would: display/audio/D-Bus/keyring.
+// Shared by Exec (background GUI apps) and ExecForeground (stdio servers).
+// Session-setup output is redirected to stderr so it never pollutes stdout — for
+// foreground stdio servers stdout must carry only JSON-RPC.
+func buildSessionEnvScript(uid int) string {
 	uidStr := fmt.Sprintf("%d", uid)
 	display := HostDisplay()
-	script := fmt.Sprintf(
+	return fmt.Sprintf(
 		`export DISPLAY=%s
 export XAUTHORITY=/run/host-xauthority
 export WAYLAND_DISPLAY=/run/host-wayland
@@ -224,21 +285,27 @@ fi
 # activation environment lacks DISPLAY/XAUTHORITY and the GTK identity broker
 # crashes on activation (Edge can't authenticate), and the keyring stays locked.
 if [ -x /usr/local/bin/intuneme-session-setup ]; then
-    /usr/local/bin/intuneme-session-setup
-fi
-nohup %s >/dev/null 2>&1 &`,
-		display, uidStr, uidStr, command,
+    /usr/local/bin/intuneme-session-setup >&2
+fi`,
+		display, uidStr, uidStr,
 	)
-	nsenterArgs := []string{
+}
+
+// buildNsenterArgs returns the nsenter argument vector (sans the leading "sudo")
+// that enters the container's namespaces and runs script as user via a non-login
+// bash. The shape matches the intuneme-exec sudoers rule exactly.
+func buildNsenterArgs(leaderPID, user, script string) []string {
+	return []string{
 		"nsenter",
 		"-t", leaderPID,
 		"-m", "-u", "-i", "-n", "-p",
 		"--", "/bin/su", "-s", "/bin/bash", user, "-c", script,
 	}
-	if _, err := r.Run("sudo", nsenterArgs...); err != nil {
-		return fmt.Errorf("exec in container failed: %w", err)
-	}
-	return nil
+}
+
+// ShellQuote single-quotes s for safe interpolation into a /bin/sh command.
+func ShellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
 // Boot starts the nspawn container in the background using sudo.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ nav:
   - User Guide:
       - Daily Workflow: user-guide/daily-workflow.md
       - Broker Proxy (SSO): user-guide/broker-proxy.md
+      - MCP Servers: user-guide/mcp-servers.md
       - Device Hotplug: user-guide/device-hotplug.md
       - GNOME Extension: user-guide/gnome-extension.md
       - Nvidia GPU: user-guide/nvidia-gpu.md

--- a/site/reference/configuration.md
+++ b/site/reference/configuration.md
@@ -20,6 +20,8 @@ The location can be overridden with the `--root` flag on any command. If you use
 | `host_user` | string | `$USER` | Username of the host user. Set automatically by `intuneme init`. |
 | `broker_proxy` | bool | `false` | Enable the host-side D-Bus broker proxy. When `true`, `intuneme start` sets up the identity broker forwarding so host applications (Edge, VS Code) can use the container's Intune enrollment for SSO. See [Broker Proxy](../user-guide/broker-proxy.md). |
 | `insiders` | bool | `false` | Use the insiders channel container image (`ghcr.io/frostyard/ubuntu-intune:insiders`) instead of the stable release. Can be set at init time with `--insiders` and affects `intuneme recreate`. |
+| `mcp_binary` | string | _(unset)_ | Host path to a self-contained MCP server binary that `intuneme mcp` runs inside the container. Any MCP server works; there is no built-in default. The binary's directory is bind-mounted into the container at runtime, so it stays out of the rootfs and survives `recreate`. Override per-invocation with `intuneme mcp --binary`. See [MCP Servers](../user-guide/mcp-servers.md). |
+| `mcp_args` | array of strings | _(empty)_ | Default arguments passed to the MCP server binary by `intuneme mcp`. For a server whose stdio mode is a subcommand, set e.g. `mcp_args = ["mcp"]` so the VS Code config can be just `["mcp"]`. Trailing `intuneme mcp -- args...` override these. |
 
 ## Example
 
@@ -32,9 +34,9 @@ host_uid = 1000
 host_user = "alice"
 broker_proxy = false
 insiders = false
+mcp_binary = ""
+mcp_args = []
 ```
-
-## Modifying the configuration
 
 Most fields are set once by `intuneme init` and rarely need changing. The `broker_proxy` field is managed by:
 

--- a/site/reference/storage.md
+++ b/site/reference/storage.md
@@ -25,6 +25,7 @@ The data root can be overridden with `--root <path>` on any command.
 | Path | Description |
 |------|-------------|
 | `/run/intuneme/devices/` | Udev forwarded device state (tmpfs, only while running) |
+| `/opt/intuneme-mcp/` | Host directory of an MCP server binary, bind-mounted read-only by `intuneme mcp` (runtime-only; re-established on demand, never enters the rootfs) |
 | `/run/host-nvidia/0/`, `/run/host-nvidia/1/`, ... | Nvidia host library directories bind-mounted read-only into the container (only on Nvidia systems) |
 
 ## Container home directory

--- a/site/user-guide/mcp-servers.md
+++ b/site/user-guide/mcp-servers.md
@@ -1,0 +1,91 @@
+# MCP Servers
+
+`intuneme mcp` runs a [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server **inside the container**, in the foreground, with its standard input/output wired straight to the caller. This lets a host-side client such as VS Code talk to an MCP server that must authenticate against the container's enrolled tenant — without enabling the broker proxy.
+
+## When to use this
+
+Use `intuneme mcp` instead of the [broker proxy](broker-proxy.md) when the MCP server has to use the **container's** Intune identity. The most common reason is running two tenants at once: one enrolled on the host and a second, separate tenant inside intuneme. The broker proxy can only forward a single broker onto the host session bus, so a server that needs the container tenant has to run *inside* the container — which is exactly what this command does.
+
+If you only have one tenant and it is enrolled in the container, the broker proxy is usually simpler: it lets host-native apps (including a host-native MCP server) get SSO without entering the container at all.
+
+## How it works
+
+1. The server binary lives on the **host**, outside the container rootfs.
+2. `intuneme mcp` bind-mounts the binary's directory into the running container at `/opt/intuneme-mcp/` (read-only). The mount is runtime-only and is re-established on demand, so it **survives `intuneme recreate`** and never becomes part of the image layer.
+3. The binary is launched in the container's namespaces (via the same `nsenter` path used by `intuneme open`), in the **foreground** with no TTY, so JSON-RPC flows cleanly over stdio.
+4. The container session is initialized first (display, D-Bus, keyring) so a server that triggers interactive sign-in can reach the container's identity broker.
+
+```
+HOST                                     intuneme container (enrolled tenant)
+────                                     ───────────────────────────────────
+VS Code
+  └─ spawns  intuneme mcp ──nsenter──▶   server binary  (stdio ⇄ VS Code)
+                                              └─ MSAL → container session bus
+                                                       microsoft-identity-broker
+```
+
+## Provide a server binary
+
+Point intuneme at a **self-contained** server binary on the host (one that needs no runtime installed in the container). Any MCP server works — there is no assumption about a particular tool.
+
+For a .NET server, publish a single-file, self-contained build:
+
+```bash
+dotnet publish -r linux-x64 --self-contained -p:PublishSingleFile=true
+```
+
+!!! note
+    A self-contained .NET `linux-x64` build targets a low glibc baseline, so building on the host and running it in the Ubuntu 24.04 container works. If you hit a glibc/ABI error, build or extract the binary from inside the container instead (`intuneme shell`).
+
+### Point intuneme at the binary
+
+Place the binary anywhere on the host outside the rootfs and `~/Intune` (e.g. `~/.local/share/intuneme/mcp/`). Set the path and any server arguments in `config.toml`:
+
+```toml
+mcp_binary = "/home/alice/.local/share/intuneme/mcp/server"
+mcp_args = ["mcp"]   # arguments handed to the server binary; e.g. a stdio subcommand
+```
+
+`mcp_args` are the arguments handed to the server binary. If the server starts its stdio mode via a subcommand, put it here; a server that starts with no subcommand can leave `mcp_args` empty. Override per-invocation with `intuneme mcp --binary <path>` or trailing `intuneme mcp -- <args>`.
+
+## Configure VS Code
+
+Add the server to `.vscode/mcp.json` (workspace) or your user `mcp.json`. The JSON key is the server's display name; the server's own subcommand lives in `mcp_args`, so the config stays minimal:
+
+```json
+{
+  "servers": {
+    "my-server": {
+      "type": "stdio",
+      "command": "intuneme",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+Here `"my-server"` is just the name shown in VS Code, and `["mcp"]` is the `intuneme` subcommand. The server's own arguments come from `mcp_args` in `config.toml`. To pass server arguments inline instead, append them after `--`: `"args": ["mcp", "--", "<server-arg>"]`.
+
+## Verify before wiring up the client
+
+The approach only yields a compliant token if the server's identity stack actually uses the **Linux broker**. Confirm the broker is reachable from inside the container first:
+
+```bash
+intuneme shell
+# inside the container:
+dbus-send --session --print-reply --dest=com.microsoft.identity.broker1 \
+  /com/microsoft/identity/broker1 \
+  com.microsoft.identity.Broker1.getLinuxBrokerVersion \
+  string:"1.0" string:"test" string:"{}"
+```
+
+A version string back means the broker is live. Then run the server once inside the container and confirm it authenticates silently rather than falling back to a browser or device-code flow.
+
+## Requirements
+
+- Container must be running (`intuneme start`)
+- The tenant must be enrolled in Intune (run `intune-portal` from `intuneme shell` if not yet enrolled)
+- A self-contained server binary on the host (`mcp_binary` or `--binary`)
+
+!!! warning
+    The server runs with the container user's session and can mint tokens against the enrolled tenant. Only run servers you trust.

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -63,6 +63,8 @@ The script conditionally sets Wayland, PipeWire, PulseAudio, Nvidia, and D-Bus v
 
 A sudoers rule at `/etc/sudoers.d/intuneme-exec` makes this passwordless so the GNOME extension can launch apps without a terminal. See [CLAUDE.md](../CLAUDE.md) for why alternatives (`machinectl shell`, `systemd-run`) don't work.
 
+`nspawn.ExecForeground()` is the foreground sibling of `Exec()`: same `nsenter` shape (so it reuses the same sudoers rule), same session prologue, but it runs the command with `exec` and the caller's stdin/stdout/stderr attached instead of `nohup … &`. This is what `intuneme mcp` uses to run an MCP server in the container with its stdio wired to a host client (e.g. VS Code) — backgrounding or a TTY would break JSON-RPC framing. The shared session prologue is `buildSessionEnvScript()`; for the foreground path the `intuneme-session-setup` output is sent to stderr so stdout carries only protocol traffic.
+
 ### Bind Mount Strategy
 
 | Type | Host Path | Container Path | Lifecycle |
@@ -78,6 +80,7 @@ A sudoers rule at `/etc/sudoers.d/intuneme-exec` makes this passwordless so the 
 | Nvidia libs | Host lib dirs (from `ldconfig`) | `/run/host-nvidia/<index>/` | Read-only; when Nvidia detected |
 | Nvidia ICD | `/usr/share/vulkan/icd.d/nvidia_icd.json` etc. | Same | Read-only; when Nvidia detected |
 | Broker runtime | `~/.local/share/intuneme/runtime` | `/run/user/<uid>` | When broker proxy enabled |
+| MCP binary dir | dir of `mcp_binary` (or `--binary`) | `/opt/intuneme-mcp` (read-only) | Runtime-only; bound on demand by `intuneme mcp`, survives recreate |
 
 ### Device Hotplug Forwarding
 


### PR DESCRIPTION
Added a way of running MCP servers from within the container environment that _might_ need access to MSAL/Intune for authentication purposes. An example for this would be [Microsoft's `work-iq` MCP server](https://github.com/microsoft/work-iq).