### PR TITLE
chore: sync agent skills from frostyard/core

### DIFF
--- a/.agents/skills/frostyard-go-repo/.synced-from-core
+++ b/.agents/skills/frostyard-go-repo/.synced-from-core
@@ -1,0 +1,2 @@
+Managed by frostyard/core — edit there, not here (ADR-0026).
+Source: https://github.com/frostyard/core/tree/main/.agents/skills/frostyard-go-repo

--- a/.agents/skills/frostyard-go-repo/SKILL.md
+++ b/.agents/skills/frostyard-go-repo/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: frostyard-go-repo
+description: Structure, build, test, and release a frostyard Go repository the way updex does — SDK-first layout, clix CLI entry, Makefile check gate, golangci-lint v2, GoReleaser Pro with svu-tagged releases and a nightly dev snapshot. Use whenever creating a new frostyard Go repo, adding CLI/release tooling to one, or making an existing one match org conventions.
+---
+
+# Build a frostyard Go repository
+
+Produce a Go repo that matches frostyard's house pattern, extracted from
+[frostyard/updex](https://github.com/frostyard/updex) — the canonical
+exemplar; when this document and updex disagree, updex wins. "Done" is: `make
+check` passes, CI is green on the test workflow, and a tag would produce a
+GoReleaser release.
+
+## Layout: SDK-first
+
+All logic lives in a public SDK package; the CLI is a thin shell over it.
+For a project named `<name>`:
+
+```
+go.mod                    module github.com/frostyard/<name>, current Go (updex: 1.26)
+<name>/                   public SDK: a Client struct + methods; the real API
+cmd/<name>/               Cobra command handlers: parse flags, call SDK, format output
+cmd/<name>-cli/main.go    entry point: clix.App{Version, Commit, Date, BuiltBy}.Run(NewRootCmd())
+internal/                 unexported helpers (retry, testutil, …)
+tests/e2e/                black-box tests: build the real binary, run it as a subprocess
+scripts/                  completions.sh, manpages.sh (GoReleaser before-hooks)
+```
+
+Rules:
+
+- **SDK code never imports CLI packages.** SDK methods take a
+  `context.Context` and an options struct, return result structs + error.
+  Never add package-level flag state to the SDK — extend the options struct.
+- Use the org commons: [`github.com/frostyard/clix`](https://github.com/frostyard/clix)
+  (fang/cobra wrapper: version strings, common flags, JSON output, reporter
+  factory) and [`github.com/frostyard/std`](https://github.com/frostyard/std).
+  `main.go` sets `version/commit/date/builtBy` vars for ldflags injection —
+  copy `updex/cmd/updex-cli/main.go`.
+- CLI output: JSON behind a `--json` flag, text tables otherwise.
+- Error messages: lowercase, no trailing punctuation, wrap with
+  `fmt.Errorf("context: %w", err)`.
+- Modern Go idioms: `any`, `slices`/`maps`/`cmp`, `t.Context()`,
+  `wg.Go()`, `omitzero` JSON tags.
+- Tests: `t.TempDir()` for filesystem work; mockable `Runner` interfaces for
+  anything that shells out (see `updex/sysext/mock_runner.go`); e2e tests
+  stay read-only so they need no root.
+
+## Steps
+
+1. **Scaffold** the layout above. Start `go.mod` with
+   `go mod init github.com/frostyard/<name>`.
+2. **Copy the toolchain files from updex** and substitute the project name:
+   - `Makefile` — targets `build`, `install`, `clean`, `fmt`, `lint`,
+     `test`, `test-cover`, `tidy`, `check` (= fmt + lint + test), `bump`,
+     `help`. `build` injects `-X main.version/commit/date/builtBy` ldflags.
+   - `.golangci.yml` — v2 config, `default: standard` linters, gofmt
+     formatter, errcheck excluded in `_test.go`.
+   - `.svu.yaml` — svu config (`tag.prefix: "v"`, `v0: true`).
+   - `.goreleaser.yaml` — `version: 2`, `pro: true`; CGO disabled,
+     linux amd64+arm64, `-trimpath`, ldflags as above; before-hooks run
+     `scripts/completions.sh` and `scripts/manpages.sh`; nfpm deb/rpm/apk
+     packages named `frostyard-<name>` shipping completions + manpage;
+     conventional-commit changelog groups; `nightly:` publishing a single
+     `dev` tag pre-release (`keep_single_release: true`).
+   - `scripts/completions.sh` / `scripts/manpages.sh` — build the binary,
+     emit `completions/<name>.{bash,zsh,fish}` and `manpages/<name>.1.gz`
+     (clix/fang provides the `completion` and `man` subcommands).
+3. **Copy the workflows** from `updex/.github/workflows/`:
+   - `test.yml` — jobs: golangci-lint, govulncheck, unit tests with Codecov
+     OIDC upload, e2e tests, `-race`, verify (`go mod tidy` diff, `go vet`,
+     `gofmt -l`), and a linux amd64/arm64 build matrix. Pin actions by SHA.
+   - `release.yml` — on tag push: GoReleaser Pro (`distribution:
+     goreleaser-pro`, needs `secrets.GORELEASER_KEY`) then publish packages
+     to the org apt/rpm repo via `frostyard/repogen`'s `publish-to-r2`
+     action (needs the `R2_*` secrets).
+   - `snapshot.yml` — nightly GoReleaser `release --nightly --clean` under
+     the `dev` tag after green `main` tests. Keep its concurrency group
+     `cancel-in-progress: true`: overlapping runs recreate the same release
+     and collide uploading identically named assets.
+4. **Write the repo's agent surface** (CLAUDE.md/AGENTS.md per the repo's
+   instruction-surface convention): build commands, architecture map,
+   code-pattern rules — mirror updex's CLAUDE.md sections.
+5. **Verify**: `make check` passes locally; push and confirm the test
+   workflow is green; `git tag v0.1.0 && git push origin v0.1.0` (or `make
+   bump`, which runs build/test/fmt/lint, requires a clean tree, then tags
+   `svu next` and pushes the tag) produces a GoReleaser release.
+
+## Releasing day-to-day
+
+- Use conventional commits (`feat:`, `fix:`, `docs:`, …) — the changelog
+  groups by them and svu derives the next version from them.
+- `make bump` is the release command; never hand-craft versions.
+- The `dev` pre-release is the rolling snapshot; real releases are svu tags.
+
+## Pitfalls
+
+- GoReleaser config is **Pro** (`pro: true`); running it with the OSS
+  distribution fails. CI needs `GORELEASER_KEY`.
+- The nfpm package name is `frostyard-<name>`, not `<name>` — keep that
+  prefix so org packages sort together in the apt/rpm repo.
+- `make lint` silently skips if golangci-lint isn't installed — CI is the
+  backstop, so don't treat a quiet local `make check` as proof lint ran.
+- Don't disable the snapshot workflow's `cancel-in-progress` — see step 3.

--- a/.agents/skills/frostyard-repo-docs/.synced-from-core
+++ b/.agents/skills/frostyard-repo-docs/.synced-from-core
@@ -1,0 +1,2 @@
+Managed by frostyard/core — edit there, not here (ADR-0026).
+Source: https://github.com/frostyard/core/tree/main/.agents/skills/frostyard-repo-docs

--- a/.agents/skills/frostyard-repo-docs/SKILL.md
+++ b/.agents/skills/frostyard-repo-docs/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: frostyard-repo-docs
+description: Give a frostyard repo core's four-category docs/ shape (adr/, design/, specs/, plans/ + indexed README), migrate any legacy yeti/ or cairn/ AI-docs tree into it, and keep the design/spec docs current with .memory/ learnings folded in. Use whenever asked to update a frostyard repo's architecture docs, after landing a significant change, when docs have drifted from the code, to retire a yeti/ or cairn/ directory, or to scaffold docs/ in a repo that lacks the shape.
+---
+
+# frostyard-repo-docs — core's docs shape, in every repo
+
+Every frostyard repo keeps one documentation tree, `docs/`, in the same
+shape as frostyard/core's
+([core ADR-0025](../../../docs/adr/0025-consolidate-repository-docs-into-docs.md)):
+
+| Directory | Question | Contents |
+| --- | --- | --- |
+| `docs/adr/` | **Why** did we choose this? | Repo-local ADRs — immutable once accepted; org-wide decisions go to core instead |
+| `docs/design/` | **How** does it fit together? | Living architecture docs; `overview.md` is the entry point |
+| `docs/specs/` | **What exactly** is the contract? | Precise interface/format definitions, changed only alongside code |
+| `docs/plans/` | **When/in what order** do we build? | Phased plans with "Done when" outcomes |
+
+`docs/README.md` carries this table plus an index of every doc.
+`docs/org-adrs.md` lists the core ADRs binding the repo, linked from the
+index. There is no separate "AI docs" directory — *all* docs are written to
+be maximally useful in an agent's context window (style rules below). This
+skill descends from the retired yeti service's doc-maintainer job
+([prompt](https://github.com/frostyard/yeti/blob/main/src/policies/doc-maintainer.md)).
+
+## Step 0 — Scaffold and migrate (once per repo)
+
+If the repo lacks the shape, or still has a `yeti/`/`cairn/` tree:
+
+1. Create the four category directories and seed each with core's
+   canonical template (do not invent your own):
+   `https://raw.githubusercontent.com/frostyard/core/main/docs/<category>/TEMPLATE.md`
+   for `adr`, `design`, `specs`, `plans`.
+2. Create `docs/README.md` modeled on
+   `https://raw.githubusercontent.com/frostyard/core/main/docs/README.md`:
+   the category table, an index section per category, and the conventions
+   block (new docs start from the category TEMPLATE; new decision → new
+   ADR with the next number; adding a doc means indexing it). Index every
+   pre-existing `docs/*.md` file where it stands — do **not** force-move
+   uncategorized process docs; categorize them opportunistically later.
+3. Migrate the legacy tree with `git mv`:
+   - `OVERVIEW.md` → `docs/design/overview.md`
+   - contract/reference docs (APIs, file formats, config references) →
+     `docs/specs/<name>.md`; other subsystem docs → `docs/design/<name>.md`
+   - `learnings/*` → fold each into the right doc now and delete it; a
+     learning not yet foldable moves to the `.memory/` inbox.
+
+   The old directory must end up gone.
+4. Update **every** reference to the old paths — they are load-bearing.
+   Search broadly (`grep -rIn 'yeti\|cairn' . --exclude-dir=.git`) and
+   expect hits in: `AGENTS.md`/`CLAUDE.md`/`.github/copilot-instructions.md`,
+   workflow `paths-ignore` lists (rename, don't drop — though `docs/**` is
+   often already listed, making the old entry deletable), coverage ignores
+   (`codecov.yml`), `.mill.toml` context docs, `.github/prompts/*.md`,
+   `.knowledge/README.md`, and doc-consistency tests that pin literal old
+   paths (e.g. chairlift's `internal/installcheck`).
+5. Add (or update) a short "Documentation rules" section in `AGENTS.md`
+   pointing at `docs/README.md`'s table and conventions, and stating that
+   repo-local decisions get an ADR in `docs/adr/` while org-wide ones go
+   to frostyard/core.
+6. Run the repo's gate (`make ci` or equivalent). Fix what the move broke;
+   weaken nothing.
+7. Commit the scaffold+migration separately from content rewrites:
+   `docs: adopt core docs shape; fold yeti/ into docs/ (frostyard/core ADR-0025)`.
+
+## Keeping the docs current
+
+1. Read the codebase first; if updating, also read `docs/design/overview.md`
+   **and every doc it links to**. Preserve accurate content, fix anything
+   outdated.
+2. `docs/design/overview.md` is the entry point and must cover:
+   - **Purpose** — what this repo does and its role (2–3 sentences)
+   - **Architecture** — key directories, modules, how they fit together
+   - **Key Patterns** — important conventions, data flow, design decisions
+   - **Configuration** — key config values and environment variables
+
+   Keep it 200–500 lines; link out rather than inline detail.
+3. Complex subsystems get dedicated docs — `docs/design/` for how-it-works,
+   `docs/specs/` for exact contracts — one subject each, linked from
+   overview.md and indexed in `docs/README.md`.
+4. **Record decisions where you find them.** A "why is it done this way?"
+   whose answer is "someone decided" deserves an ADR in `docs/adr/` (next
+   free number, from the TEMPLATE) — or, if it binds more than this repo,
+   an ADR in frostyard/core plus a line in `docs/org-adrs.md`.
+5. **Drain the inbox.** `.memory/` entries (corrections, learnings) are
+   seeds, not archives: fold each into the right doc — or into `AGENTS.md`
+   when it is a rule of engagement — then delete the entry. The inbox must
+   trend toward empty.
+6. Mine merged PRs and closed issues since the last docs commit for
+   undocumented decisions. Only document what the current code reflects.
+7. Keep links bidirectional (ADR ↔ design ↔ spec ↔ plan) and the index
+   complete. Docs only — no code changes in the same commit. Commit as:
+   `docs: update architecture docs`.
+
+## Capturing learnings between passes
+
+While doing *any* work in a frostyard repo, when you hit a workaround for an
+upstream bug (link the issue), a non-obvious pattern required for
+correctness, a non-obvious convention, or a hard-won trial-and-error
+discovery — fold it into the right `docs/` page immediately if small, or
+drop it in `.memory/` to be folded by the next pass. Never write one-off
+task notes, obvious knowledge, changelogs, or "append here" sections.
+
+## Writing style (applies to all of docs/)
+
+Optimize for a reader with a context window: dense, factual, structured;
+state invariants and the *why* behind them; name exact paths, commands, and
+constants; skip marketing prose and content duplicated from the README. If
+a fact is enforced by a test or guard, say which one.


### PR DESCRIPTION
Automated skill sync from [frostyard/core](https://github.com/frostyard/core) @ 02fa3a6 per [ADR-0026](https://github.com/frostyard/core/blob/main/docs/adr/0026-distribute-core-skills-via-sync-prs.md).

Synced skills: frostyard-go-repo frostyard-repo-docs

These directories are managed in core — edit them there, not here. Local edits are overwritten by the next sync.

Risk tier: 1 — documentation/skills only, no code or workflow changes.